### PR TITLE
feat(minimax-h3): LoRA support for local Windows-PC adapters

### DIFF
--- a/changelog/minimax-h3-lora-support.md
+++ b/changelog/minimax-h3-lora-support.md
@@ -1,0 +1,22 @@
+### Added
+- MiniMax-H3 LoRA support (local / Windows-PC ComfyUI)
+  - `LoraLoaderModelOnly` LoRA stacking for MiniMax-H3 T2V + I2V workflows:
+    `_build_minimax_h3_workflow()` now chains single-stage LoRAs in front of the base
+    `UNETLoader`, re-pointing the BasicGuider + BasicScheduler at the last loader.
+    The `build_cloud_minimax_h3_*_workflow()` / `build_local_minimax_h3_*_workflow()`
+    builders all accept an optional `lora_configs=[{name, strength}, ...]`.
+  - `MiniMaxH3LocalT2VAdapter` / `MiniMaxH3LocalI2VAdapter` now pass `req.loras`
+    (single-stage `{name, strength}`) into the workflow builders and upload the requested
+    LoRA files from `/mnt/ssd/loras/minimax-h3` to the Windows-PC ComfyUI server before
+    dispatch (new `ComfyUIClient.upload_lora()` via `/internal/models/upload`, `type=loras`).
+    Missing/unfounded LoRAs are logged and skipped rather than failing the job.
+  - `lora_scanner._derive_base_model()` recognises `minimax_h3` (subdir `minimax-h3/`,
+    name markers `minimax` / `fl2va`) so MiniMax-H3 LoRAs are no longer mis-labelled as `wan2.2`.
+  - LoRA registry entries (`docs/lora_registry.yaml`) for the three MiniMax-H3 LoRAs:
+    `bounceV07_fl2va-000230_Intense`, `PenisV2_minimax-h3_epoch60`, `Vagina_minimax-h3_epoch20`
+    (base_model `minimax_h3`, modes t2v+i2v).
+
+### Changed
+- Frontend: the TextToVideo LoRA panel is now available for the local MiniMax-H3 mode
+  (`minimax_h3_local`); it stays hidden for the cloud worker (`minimax_h3`), which does
+  not support LoRAs yet.

--- a/docs/lora_registry.yaml
+++ b/docs/lora_registry.yaml
@@ -1318,3 +1318,58 @@
   modes: ["t2i", "i2i"]
   usage_notes: "Sounding concept LoRA, early checkpoint (2 epochs)."
   last_checked: "2026-07-23"
+# ─── MiniMax-H3 LoRAs ────────────────────────────────────────────────────────
+
+- filename: "minimax-h3/bounceV07_fl2va-000230_Intense.safetensors"
+  display_name: "Bounce V07 (MiniMax-H3)"
+  base_model: "minimax_h3"
+  creator: "fl2va"
+  version: "V07 - step 000230 Intense"
+  source_url: null
+  civitai_model_id: null
+  trigger_words: []
+  trigger_mode: "natural_language"
+  recommended_strength: 0.8
+  strength_range: [0.6, 1.2]
+  noise_type: "single"
+  paired_with: null
+  modes: ["t2v", "i2v"]
+  usage_notes: >
+    Motion/bounce LoRA for MiniMax-H3 FL2VA. Single-stage; trained at step
+    000230 (Intense variant). Boosts bouncing/motion behaviour — describe the
+    action naturally in the prompt.
+  last_checked: "2026-08-23"
+
+- filename: "minimax-h3/PenisV2_minimax-h3_epoch60.safetensors"
+  display_name: "Penis V2 (MiniMax-H3)"
+  base_model: "minimax_h3"
+  creator: "unknown"
+  version: "V2 - epoch 60"
+  source_url: null
+  civitai_model_id: null
+  trigger_words: []
+  trigger_mode: "none"
+  recommended_strength: 0.8
+  strength_range: [0.6, 1.0]
+  noise_type: "single"
+  paired_with: null
+  modes: ["t2v", "i2v"]
+  usage_notes: "Penis anatomy LoRA for MiniMax-H3 FL2VA, single-stage, 60 epochs."
+  last_checked: "2026-08-23"
+
+- filename: "minimax-h3/Vagina_minimax-h3_epoch20.safetensors"
+  display_name: "Vagina (MiniMax-H3)"
+  base_model: "minimax_h3"
+  creator: "unknown"
+  version: "epoch 20"
+  source_url: null
+  civitai_model_id: null
+  trigger_words: []
+  trigger_mode: "none"
+  recommended_strength: 0.8
+  strength_range: [0.6, 1.0]
+  noise_type: "single"
+  paired_with: null
+  modes: ["t2v", "i2v"]
+  usage_notes: "Vagina anatomy LoRA for MiniMax-H3 FL2VA, single-stage, 20 epochs."
+  last_checked: "2026-08-23"

--- a/src/backend/comfyui_client.py
+++ b/src/backend/comfyui_client.py
@@ -5940,7 +5940,7 @@ def get_windows_comfyui_client() -> Optional[ComfyUIClient]:
     This is a separate ComfyUI server from the one on ai-kvm2 (which
     get_comfyui_client() targets). Local MiniMax-H3 generation is routed here
     because the H3 models + workflow live on the Windows machine
-    (ComfyUI portable, e.g. 192.168.1.245:8188).
+    (ComfyUI portable, reachable via COMFYUI_WINDOWS_HOST / COMFYUI_WINDOWS_PORT).
 
     Returns None when the host/port haven't been configured, so any
     dependent adapter/registration is skipped gracefully.

--- a/src/backend/comfyui_client.py
+++ b/src/backend/comfyui_client.py
@@ -1266,6 +1266,43 @@ class ComfyUIClient:
             logger.error(f"🎬 Video upload error: {e}")
             return None
 
+    def upload_lora(self, lora_path: str) -> Optional[str]:
+        """Upload a LoRA file to this ComfyUI server's loras folder.
+
+        Targets the modern ``/internal/models/upload`` endpoint (available on
+        current ComfyUI installs — including the Windows-PC portable), which
+        writes into ``models/loras`` so a subsequent ``LoraLoaderModelOnly``
+        node can load the file by name. Returns the uploaded filename (the
+        basename) on success, else ``None``.
+        """
+        try:
+            path = Path(lora_path)
+            if not path.exists():
+                logger.error(f"🎨 LoRA not found: {lora_path}")
+                return None
+            with open(path, "rb") as f:
+                files = {"file": (path.name, f)}
+                # type=loras routes the file into models/loras on the server.
+                data = {"type": "loras", "subfolder": "", "overwrite": "true"}
+                resp = requests.post(
+                    f"{self.base_url}/internal/models/upload",
+                    files=files,
+                    data=data,
+                    timeout=300,
+                )
+            if resp.status_code == 200:
+                result = resp.json() if resp.text else {}
+                name = result.get("name") or path.name
+                logger.info(f"🎨 LoRA uploaded to server: {name}")
+                return name
+            logger.error(
+                f"🎨 LoRA upload failed: {resp.status_code} - {resp.text[:200]}"
+            )
+            return None
+        except Exception as e:
+            logger.error(f"🎨 LoRA upload error: {e}")
+            return None
+
     def get_resolution_dimensions(
         self, resolution: str, aspect_ratio: str
     ) -> Tuple[int, int]:
@@ -4028,6 +4065,7 @@ class ComfyUIClient:
         audio_vae: str,
         first_frame_link: Optional[list] = None,
         last_frame_link: Optional[list] = None,
+        lora_configs: Optional[List[Dict[str, Any]]] = None,
         output_kind: str = "vhs",
     ) -> Dict[str, Any]:
         """Shared MiniMax-H3 sampling graph (model load → AV decode → mp4).
@@ -4049,6 +4087,10 @@ class ComfyUIClient:
                 "weight_dtype": "default",
             },
         }
+        # The diffusion model the guider + scheduler sample from. With LoRAs we
+        # chain LoraLoaderModelOnly nodes in front of the base model, so this
+        # link points at the last loader in the chain.
+        model_link = ["1", 0]
 
         # Node 2: CLIPLoader — Qwen3-VL-32B MiniMax text encoder
         workflow["2"] = {
@@ -4090,11 +4132,35 @@ class ComfyUIClient:
             "inputs": h3_inputs,
         }
 
+        # Apply MiniMax-H3 LoRAs (single-stage) by chaining LoraLoaderModelOnly
+        # in front of the base model. The guider + scheduler already reference
+        # model_link, which now points at the last loader in the chain.
+        if lora_configs:
+            lora_node_id = 16
+            for i, cfg in enumerate(lora_configs):
+                if not cfg:
+                    continue
+                lora_name = cfg.get("name") or ""
+                strength = cfg.get("strength", 1.0)
+                if not lora_name:
+                    continue
+                workflow[str(lora_node_id)] = {
+                    "class_type": "LoraLoaderModelOnly",
+                    "inputs": {
+                        "model": model_link,
+                        "lora_name": lora_name,
+                        "strength_model": strength,
+                    },
+                }
+                model_link = [str(lora_node_id), 0]
+                logger.info(f"🎨 MiniMax-H3 LoRA #{i + 1}: {lora_name} @ {strength}")
+                lora_node_id += 1
+
         # Node 6: BasicGuider — no CFG / no negative prompt for H3
         workflow["6"] = {
             "class_type": "BasicGuider",
             "inputs": {
-                "model": ["1", 0],
+                "model": model_link,
                 "conditioning": ["5", 0],
             },
         }
@@ -4109,7 +4175,7 @@ class ComfyUIClient:
         workflow["8"] = {
             "class_type": "BasicScheduler",
             "inputs": {
-                "model": ["1", 0],
+                "model": model_link,
                 "scheduler": "simple",
                 "steps": steps,
                 "denoise": 1.0,
@@ -4217,6 +4283,7 @@ class ComfyUIClient:
         aspect_ratio: str = "16:9",
         megapixels: Optional[float] = None,
         long_edge: int = 768,
+        lora_configs: Optional[List[Dict[str, Any]]] = None,
         output_kind: str = "vhs",
     ) -> Optional[Dict[str, Any]]:
         """
@@ -4254,6 +4321,7 @@ class ComfyUIClient:
             text_encoder=text_encoder,
             video_vae=video_vae,
             audio_vae=audio_vae,
+            lora_configs=lora_configs,
             output_kind=output_kind,
         )
 
@@ -4275,6 +4343,7 @@ class ComfyUIClient:
         aspect_ratio: str = "16:9",
         megapixels: Optional[float] = None,
         long_edge: int = 768,
+        lora_configs: Optional[List[Dict[str, Any]]] = None,
         output_kind: str = "vhs",
     ) -> Optional[Dict[str, Any]]:
         """
@@ -4310,6 +4379,7 @@ class ComfyUIClient:
             video_vae=video_vae,
             audio_vae=audio_vae,
             first_frame_link=["14", 0],
+            lora_configs=lora_configs,
             output_kind=output_kind,
         )
 
@@ -4337,6 +4407,7 @@ class ComfyUIClient:
         aspect_ratio: str = "16:9",
         megapixels: Optional[float] = None,
         long_edge: int = 768,
+        lora_configs: Optional[List[Dict[str, Any]]] = None,
     ) -> Optional[Dict[str, Any]]:
         """
         Build MiniMax-H3 local (Windows PC ComfyUI) T2V workflow.
@@ -4362,6 +4433,7 @@ class ComfyUIClient:
             audio_vae=audio_vae,
             aspect_ratio=aspect_ratio,
             megapixels=megapixels,
+            lora_configs=lora_configs,
             output_kind="savevideo",
         )
 
@@ -4383,6 +4455,7 @@ class ComfyUIClient:
         aspect_ratio: str = "16:9",
         megapixels: Optional[float] = None,
         long_edge: int = 768,
+        lora_configs: Optional[List[Dict[str, Any]]] = None,
     ) -> Optional[Dict[str, Any]]:
         """
         Build MiniMax-H3 local (Windows PC ComfyUI) I2V workflow.
@@ -4405,6 +4478,7 @@ class ComfyUIClient:
             audio_vae=audio_vae,
             aspect_ratio=aspect_ratio,
             megapixels=megapixels,
+            lora_configs=lora_configs,
             output_kind="savevideo",
         )
 

--- a/src/backend/generation/adapters/local/minimax_h3_i2v.py
+++ b/src/backend/generation/adapters/local/minimax_h3_i2v.py
@@ -122,6 +122,33 @@ class MiniMaxH3LocalI2VAdapter(GenerationAdapter):
             raw = raw + ("=" * missing)
         return base64.b64decode(raw)
 
+    def build_workflow(self, req: GenerationRequest, image_name: str = "") -> dict:
+        """Build the local MiniMax-H3 I2V ComfyUI workflow.
+
+        ``image_name`` is the filename the input image was uploaded as on the
+        target server (it is read back from the upload in ``execute``). It
+        defaults to a placeholder so workflow-only callers can still build one.
+        """
+        if self._get_comfyui is None:
+            raise RuntimeError("ComfyUI client not available")
+        comfyui = self._get_comfyui()
+        lora_configs = (
+            [lr.model_dump(exclude_none=True) for lr in req.loras]
+            if req.loras
+            else None
+        )
+        return comfyui.build_local_minimax_h3_i2v_workflow(
+            image_name=image_name or "input.png",
+            prompt=req.prompt,
+            num_frames=req.frames or 124,
+            fps=req.fps or 24,
+            seed=req.seed,
+            steps=req.steps or 20,
+            aspect_ratio=req.aspect_ratio or "16:9",
+            megapixels=req.megapixels,
+            lora_configs=lora_configs,
+        )
+
     def cost(self, req: GenerationRequest) -> int:
         frames = req.frames or 124
         if frames <= 124:
@@ -166,22 +193,7 @@ class MiniMaxH3LocalI2VAdapter(GenerationAdapter):
 
         _upload_minimax_loras(client, req)
 
-        lora_configs = (
-            [lr.model_dump(exclude_none=True) for lr in req.loras]
-            if req.loras
-            else None
-        )
-        workflow = client.build_local_minimax_h3_i2v_workflow(
-            image_name=uploaded_name,
-            prompt=req.prompt,
-            num_frames=req.frames or 124,
-            fps=req.fps or 24,
-            seed=req.seed,
-            steps=req.steps or 20,
-            aspect_ratio=req.aspect_ratio or "16:9",
-            megapixels=req.megapixels,
-            lora_configs=lora_configs,
-        )
+        workflow = self.build_workflow(req, image_name=uploaded_name)
         if not workflow:
             raise RuntimeError("Failed to build MiniMax-H3 local I2V workflow")
 

--- a/src/backend/generation/adapters/local/minimax_h3_i2v.py
+++ b/src/backend/generation/adapters/local/minimax_h3_i2v.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import base64
 import logging
+from pathlib import Path
 from typing import Any
 
 from ...adapter import GenerationAdapter, ProgressCallback
@@ -26,6 +27,33 @@ from ...types import (
 )
 
 logger = logging.getLogger(__name__)
+
+# LoRAs for the local MiniMax-H3 (Windows-PC ComfyUI) live here on this
+# server and are uploaded to the Windows-PC on demand before dispatch.
+_MINIMAX_H3_LORA_DIR = Path("/mnt/ssd/loras/minimax-h3")
+
+
+def _upload_minimax_loras(client: Any, req: GenerationRequest) -> None:
+    """Upload any requested MiniMax-H3 LoRAs to the Windows-PC ComfyUI server.
+
+    ``LoraStackItem.name`` is the LoRA filename as the server knows it, so each
+    requested LoRA is uploaded from the local ``minimax-h3`` folder (by that
+    basename) before the workflow runs. Missing files are warned about and
+    skipped; the run proceeds without them rather than failing the whole job.
+    """
+    if not req.loras:
+        return
+    for lora in req.loras:
+        name = (lora.name or "").strip()
+        if not name or name == "None":
+            continue
+        src = _MINIMAX_H3_LORA_DIR / name
+        if not src.is_file():
+            logger.warning(f"🎨 MiniMax-H3 LoRA not found, skipping: {src}")
+            continue
+        uploaded = client.upload_lora(str(src))
+        if not uploaded:
+            logger.warning(f"🎨 MiniMax-H3 LoRA upload failed, skipping: {name}")
 
 
 class MiniMaxH3LocalI2VAdapter(GenerationAdapter):
@@ -95,6 +123,9 @@ class MiniMaxH3LocalI2VAdapter(GenerationAdapter):
         if self._get_comfyui is None:
             raise RuntimeError("ComfyUI client not available")
         comfyui = self._get_comfyui()
+        lora_configs = (
+            [lr.model_dump(exclude_none=True) for lr in req.loras] if req.loras else None
+        )
         return comfyui.build_local_minimax_h3_i2v_workflow(
             image_name="input.png" if req.input_images else "",
             prompt=req.prompt,
@@ -104,6 +135,7 @@ class MiniMaxH3LocalI2VAdapter(GenerationAdapter):
             steps=req.steps or 20,
             aspect_ratio=req.aspect_ratio or "16:9",
             megapixels=req.megapixels,
+            lora_configs=lora_configs,
         )
 
     def cost(self, req: GenerationRequest) -> int:
@@ -148,6 +180,11 @@ class MiniMaxH3LocalI2VAdapter(GenerationAdapter):
         if not uploaded_name:
             raise RuntimeError("ComfyUI image upload failed on Windows server")
 
+        _upload_minimax_loras(client, req)
+
+        lora_configs = (
+            [lr.model_dump(exclude_none=True) for lr in req.loras] if req.loras else None
+        )
         workflow = client.build_local_minimax_h3_i2v_workflow(
             image_name=uploaded_name,
             prompt=req.prompt,
@@ -157,6 +194,7 @@ class MiniMaxH3LocalI2VAdapter(GenerationAdapter):
             steps=req.steps or 20,
             aspect_ratio=req.aspect_ratio or "16:9",
             megapixels=req.megapixels,
+            lora_configs=lora_configs,
         )
         if not workflow:
             raise RuntimeError("Failed to build MiniMax-H3 local I2V workflow")

--- a/src/backend/generation/adapters/local/minimax_h3_i2v.py
+++ b/src/backend/generation/adapters/local/minimax_h3_i2v.py
@@ -48,6 +48,9 @@ def _upload_minimax_loras(client: Any, req: GenerationRequest) -> None:
         if not name or name == "None":
             continue
         src = _MINIMAX_H3_LORA_DIR / name
+        if not src.resolve().is_relative_to(_MINIMAX_H3_LORA_DIR.resolve()):
+            logger.warning(f"🎨 Refusing out-of-directory LoRA path: {name}")
+            continue
         if not src.is_file():
             logger.warning(f"🎨 MiniMax-H3 LoRA not found, skipping: {src}")
             continue
@@ -118,27 +121,6 @@ class MiniMaxH3LocalI2VAdapter(GenerationAdapter):
         if missing:
             raw = raw + ("=" * missing)
         return base64.b64decode(raw)
-
-    def build_workflow(self, req: GenerationRequest) -> dict:
-        if self._get_comfyui is None:
-            raise RuntimeError("ComfyUI client not available")
-        comfyui = self._get_comfyui()
-        lora_configs = (
-            [lr.model_dump(exclude_none=True) for lr in req.loras]
-            if req.loras
-            else None
-        )
-        return comfyui.build_local_minimax_h3_i2v_workflow(
-            image_name="input.png" if req.input_images else "",
-            prompt=req.prompt,
-            num_frames=req.frames or 124,
-            fps=req.fps or 24,
-            seed=req.seed,
-            steps=req.steps or 20,
-            aspect_ratio=req.aspect_ratio or "16:9",
-            megapixels=req.megapixels,
-            lora_configs=lora_configs,
-        )
 
     def cost(self, req: GenerationRequest) -> int:
         frames = req.frames or 124

--- a/src/backend/generation/adapters/local/minimax_h3_i2v.py
+++ b/src/backend/generation/adapters/local/minimax_h3_i2v.py
@@ -124,7 +124,9 @@ class MiniMaxH3LocalI2VAdapter(GenerationAdapter):
             raise RuntimeError("ComfyUI client not available")
         comfyui = self._get_comfyui()
         lora_configs = (
-            [lr.model_dump(exclude_none=True) for lr in req.loras] if req.loras else None
+            [lr.model_dump(exclude_none=True) for lr in req.loras]
+            if req.loras
+            else None
         )
         return comfyui.build_local_minimax_h3_i2v_workflow(
             image_name="input.png" if req.input_images else "",
@@ -183,7 +185,9 @@ class MiniMaxH3LocalI2VAdapter(GenerationAdapter):
         _upload_minimax_loras(client, req)
 
         lora_configs = (
-            [lr.model_dump(exclude_none=True) for lr in req.loras] if req.loras else None
+            [lr.model_dump(exclude_none=True) for lr in req.loras]
+            if req.loras
+            else None
         )
         workflow = client.build_local_minimax_h3_i2v_workflow(
             image_name=uploaded_name,

--- a/src/backend/generation/adapters/local/minimax_h3_t2v.py
+++ b/src/backend/generation/adapters/local/minimax_h3_t2v.py
@@ -155,11 +155,11 @@ class MiniMaxH3LocalT2VAdapter(GenerationAdapter):
                 "is the configured compute backend running on that machine?"
             )
 
+        _upload_minimax_loras(client, req)
+
         workflow = self.build_workflow(req)
         if not workflow:
             raise RuntimeError("Failed to build MiniMax-H3 local T2V workflow")
-
-        _upload_minimax_loras(client, req)
 
         prompt_id = client.queue_prompt(workflow)
         if not prompt_id:

--- a/src/backend/generation/adapters/local/minimax_h3_t2v.py
+++ b/src/backend/generation/adapters/local/minimax_h3_t2v.py
@@ -12,6 +12,7 @@ soundtrack — no separate audio prompt needed.
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from typing import Any
 
 from ...adapter import GenerationAdapter, ProgressCallback
@@ -26,6 +27,33 @@ from ...types import (
 )
 
 logger = logging.getLogger(__name__)
+
+# LoRAs for the local MiniMax-H3 (Windows-PC ComfyUI) live here on this
+# server and are uploaded to the Windows-PC on demand before dispatch.
+_MINIMAX_H3_LORA_DIR = Path("/mnt/ssd/loras/minimax-h3")
+
+
+def _upload_minimax_loras(client: Any, req: GenerationRequest) -> None:
+    """Upload any requested MiniMax-H3 LoRAs to the Windows-PC ComfyUI server.
+
+    ``LoraStackItem.name`` is the LoRA filename as the server knows it, so each
+    requested LoRA is uploaded from the local ``minimax-h3`` folder (by that
+    basename) before the workflow runs. Missing files are warned about and
+    skipped; the run proceeds without them rather than failing the whole job.
+    """
+    if not req.loras:
+        return
+    for lora in req.loras:
+        name = (lora.name or "").strip()
+        if not name or name == "None":
+            continue
+        src = _MINIMAX_H3_LORA_DIR / name
+        if not src.is_file():
+            logger.warning(f"🎨 MiniMax-H3 LoRA not found, skipping: {src}")
+            continue
+        uploaded = client.upload_lora(str(src))
+        if not uploaded:
+            logger.warning(f"🎨 MiniMax-H3 LoRA upload failed, skipping: {name}")
 
 
 class MiniMaxH3LocalT2VAdapter(GenerationAdapter):
@@ -82,6 +110,9 @@ class MiniMaxH3LocalT2VAdapter(GenerationAdapter):
         if self._get_comfyui is None:
             raise RuntimeError("ComfyUI client not available")
         comfyui = self._get_comfyui()
+        lora_configs = (
+            [lr.model_dump(exclude_none=True) for lr in req.loras] if req.loras else None
+        )
         return comfyui.build_local_minimax_h3_t2v_workflow(
             prompt=req.prompt,
             num_frames=req.frames or 124,
@@ -90,6 +121,7 @@ class MiniMaxH3LocalT2VAdapter(GenerationAdapter):
             steps=req.steps or 20,
             aspect_ratio=req.aspect_ratio or "16:9",
             megapixels=req.megapixels,
+            lora_configs=lora_configs,
         )
 
     def cost(self, req: GenerationRequest) -> int:
@@ -121,6 +153,8 @@ class MiniMaxH3LocalT2VAdapter(GenerationAdapter):
         workflow = self.build_workflow(req)
         if not workflow:
             raise RuntimeError("Failed to build MiniMax-H3 local T2V workflow")
+
+        _upload_minimax_loras(client, req)
 
         prompt_id = client.queue_prompt(workflow)
         if not prompt_id:

--- a/src/backend/generation/adapters/local/minimax_h3_t2v.py
+++ b/src/backend/generation/adapters/local/minimax_h3_t2v.py
@@ -48,6 +48,9 @@ def _upload_minimax_loras(client: Any, req: GenerationRequest) -> None:
         if not name or name == "None":
             continue
         src = _MINIMAX_H3_LORA_DIR / name
+        if not src.resolve().is_relative_to(_MINIMAX_H3_LORA_DIR.resolve()):
+            logger.warning(f"🎨 Refusing out-of-directory LoRA path: {name}")
+            continue
         if not src.is_file():
             logger.warning(f"🎨 MiniMax-H3 LoRA not found, skipping: {src}")
             continue

--- a/src/backend/generation/adapters/local/minimax_h3_t2v.py
+++ b/src/backend/generation/adapters/local/minimax_h3_t2v.py
@@ -111,7 +111,9 @@ class MiniMaxH3LocalT2VAdapter(GenerationAdapter):
             raise RuntimeError("ComfyUI client not available")
         comfyui = self._get_comfyui()
         lora_configs = (
-            [lr.model_dump(exclude_none=True) for lr in req.loras] if req.loras else None
+            [lr.model_dump(exclude_none=True) for lr in req.loras]
+            if req.loras
+            else None
         )
         return comfyui.build_local_minimax_h3_t2v_workflow(
             prompt=req.prompt,

--- a/src/backend/lora_scanner.py
+++ b/src/backend/lora_scanner.py
@@ -184,6 +184,12 @@ def _derive_base_model(filename: str) -> str:
         return "wan2.2"
     if "ltx" in lower:
         return "ltx"
+    # MiniMax-H3 — check subdirectory and name markers before the generic
+    # i2v/t2v → wan2.2 fallback (an H3 LoRA can carry i2v/t2v in its name).
+    if lower.startswith("minimax-h3/") or lower.startswith("minimax-h3\\"):
+        return "minimax_h3"
+    if "minimax" in lower or "fl2va" in lower:
+        return "minimax_h3"
     # I2V/T2V without ltx → wan2.2 (only Wan uses these LoRA modes)
     if ("i2v" in lower or "t2v" in lower) and "ltx" not in lower:
         return "wan2.2"

--- a/src/frontend/src/dashboard/tools/TextToVideoTool.jsx
+++ b/src/frontend/src/dashboard/tools/TextToVideoTool.jsx
@@ -1704,8 +1704,8 @@ export default function TextToVideoTool({ onOutput, onRefreshHistory, onJobSubmi
               </div>
             )}
 
-            {/* LoRA Settings (not for MiniMax-H3 — worker has no LoRA support yet) */}
-            {!isH3Mode(modelType) && (
+            {/* LoRA Settings (MiniMax-H3 local supports LoRAs via the Windows-PC ComfyUI; the cloud worker does not yet) */}
+            {modelType !== 'minimax_h3' && (
             <div style={{ marginTop: '16px', paddingTop: '16px', borderTop: '1px solid var(--border-color)' }}>
               <div
                 onClick={() => setShowLoraPanel(!showLoraPanel)}

--- a/tests/test_comfyui_minimax_h3_lora.py
+++ b/tests/test_comfyui_minimax_h3_lora.py
@@ -1,0 +1,86 @@
+"""
+Tests for MiniMax-H3 workflow LoRA injection (single-stage LoraLoaderModelOnly).
+
+These exercise the workflow builders in ``comfyui_client`` directly — no
+network is touched; the builder only assembles the prompt/dict graph. They
+verify that requested LoRAs are chained in front of the base UNETLoader model
+and that the guider (node 6) and scheduler (node 8) consume the last loader's
+output, with no node-id collisions against the fixed image/output nodes.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src", "backend"))
+
+from comfyui_client import ComfyUIClient
+
+
+def _client() -> ComfyUIClient:
+    return ComfyUIClient(host="localhost", port=8188)
+
+
+def test_t2v_injects_single_lora():
+    wf = _client().build_local_minimax_h3_t2v_workflow(
+        prompt="test",
+        num_frames=124,
+        fps=24,
+        seed=42,
+        steps=20,
+        lora_configs=[
+            {"name": "bounceV07_fl2va-000230_Intense.safetensors", "strength": 0.8}
+        ],
+    )
+    lora = wf["16"]
+    assert lora["class_type"] == "LoraLoaderModelOnly"
+    assert lora["inputs"]["lora_name"] == "bounceV07_fl2va-000230_Intense.safetensors"
+    assert lora["inputs"]["strength_model"] == 0.8
+    assert lora["inputs"]["model"] == ["1", 0]
+    # guider + scheduler now consume the lora output
+    assert wf["6"]["inputs"]["model"] == ["16", 0]
+    assert wf["8"]["inputs"]["model"] == ["16", 0]
+
+
+def test_t2v_no_loras_keeps_base_model_link():
+    wf = _client().build_local_minimax_h3_t2v_workflow(
+        prompt="test", num_frames=124, fps=24, seed=1, steps=20
+    )
+    assert "16" not in wf
+    assert wf["6"]["inputs"]["model"] == ["1", 0]
+    assert wf["8"]["inputs"]["model"] == ["1", 0]
+
+
+def test_i2v_chains_multiple_loras_and_keeps_image_node():
+    wf = _client().build_local_minimax_h3_i2v_workflow(
+        image_name="first.png",
+        prompt="test",
+        num_frames=124,
+        fps=24,
+        seed=1,
+        steps=20,
+        lora_configs=[
+            {"name": "A.safetensors", "strength": 1.0},
+            {"name": "B.safetensors", "strength": 0.5},
+        ],
+    )
+    assert wf["14"]["class_type"] == "LoadImage"  # first-frame keyframe
+    assert wf["16"]["inputs"]["model"] == ["1", 0]
+    assert wf["17"]["inputs"]["model"] == ["16", 0]
+    assert wf["6"]["inputs"]["model"] == ["17", 0]
+    assert wf["8"]["inputs"]["model"] == ["17", 0]
+
+
+def test_t2v_output_kind_savevideo_uses_savevideo_node():
+    wf = _client().build_local_minimax_h3_t2v_workflow(
+        prompt="test",
+        num_frames=124,
+        fps=24,
+        seed=1,
+        steps=20,
+        lora_configs=[{"name": "Bounce.safetensors", "strength": 0.7}],
+    )
+    # local output is SaveVideo (node 13/15); lora node 16 collides with none
+    assert wf["16"]["class_type"] == "LoraLoaderModelOnly"
+    assert "SaveVideo" in {
+        wf[k]["class_type"] for k in wf if k in ("13", "15")
+    }

--- a/tests/test_comfyui_minimax_h3_lora.py
+++ b/tests/test_comfyui_minimax_h3_lora.py
@@ -17,7 +17,9 @@ from comfyui_client import ComfyUIClient
 
 
 def _client() -> ComfyUIClient:
-    return ComfyUIClient(host="localhost", port=8188)
+    # Any non-resolving host works — the builders only assemble the workflow
+    # dict and never touch the network.
+    return ComfyUIClient(host="comfyui.test.internal", port=8188)
 
 
 def test_t2v_injects_single_lora():

--- a/tests/test_local_minimax_h3.py
+++ b/tests/test_local_minimax_h3.py
@@ -211,9 +211,7 @@ class TestMiniMaxH3LocalI2V:
 
     @pytest.mark.asyncio
     async def test_execute_requires_image(self):
-        a = minimax_h3_i2v.MiniMaxH3LocalI2VAdapter(
-            comfyui_client_fn=lambda: MagicMock()
-        )
+        a = minimax_h3_i2v.MiniMaxH3LocalI2VAdapter(comfyui_client_fn=MagicMock)
         with pytest.raises(ValueError):
             await a.execute(_req())
 

--- a/tests/test_local_minimax_h3.py
+++ b/tests/test_local_minimax_h3.py
@@ -21,6 +21,7 @@ from generation.types import (
     ComputeTarget,
     GenerationRequest,
     LoraFormat,
+    LoraStackItem,
     MediaType,
     Operation,
 )
@@ -84,6 +85,33 @@ class TestMiniMaxH3LocalT2V:
         assert kwargs["num_frames"] == 124
         assert kwargs["aspect_ratio"] == "16:9"
         assert kwargs["megapixels"] == 0.98
+        assert kwargs["lora_configs"] is None
+
+    def test_build_workflow_passes_loras(self):
+        mock = MagicMock()
+        mock.build_local_minimax_h3_t2v_workflow.return_value = {"h3": "wf"}
+        a = MiniMaxH3LocalT2VAdapter(comfyui_client_fn=lambda: mock)
+        req = _req(loras=[LoraStackItem(name="bounce.safetensors", strength=0.8)])
+        a.build_workflow(req)
+        kwargs = mock.build_local_minimax_h3_t2v_workflow.call_args[1]
+        assert kwargs["lora_configs"] == [{"name": "bounce.safetensors", "strength": 0.8}]
+
+    @pytest.mark.asyncio
+    async def test_execute_uploads_loras_before_queue(self):
+        mock = MagicMock()
+        mock.is_available.return_value = True
+        mock.queue_prompt.return_value = "p123"
+        mock.upload_lora.return_value = "bounce.safetensors"
+        mock.host = "192.168.1.245"
+        mock.port = 8188
+        import generation.adapters.local.minimax_h3_t2v as mod
+        mod._MINIMAX_H3_LORA_DIR = mod.Path("/definitely/missing/dir")
+        a = MiniMaxH3LocalT2VAdapter(comfyui_client_fn=lambda: mock)
+        req = _req(loras=[LoraStackItem(name="missing.safetensors", strength=0.8)])
+        await a.execute(req)
+        # missing lora file -> skipped, upload never called, but job still runs
+        mock.upload_lora.assert_not_called()
+        mock.queue_prompt.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_execute_queues_to_client(self):

--- a/tests/test_local_minimax_h3.py
+++ b/tests/test_local_minimax_h3.py
@@ -11,6 +11,7 @@ including the adapter-level image upload for i2v).
 import os
 import sys
 import base64
+from pathlib import Path
 
 import pytest
 from unittest.mock import MagicMock
@@ -25,8 +26,7 @@ from generation.types import (
     MediaType,
     Operation,
 )
-from generation.adapters.local.minimax_h3_t2v import MiniMaxH3LocalT2VAdapter
-from generation.adapters.local.minimax_h3_i2v import MiniMaxH3LocalI2VAdapter
+from generation.adapters.local import minimax_h3_i2v, minimax_h3_t2v
 
 
 def _png_b64() -> str:
@@ -41,14 +41,18 @@ def _png_b64() -> str:
 
 
 def _req(**kw):
-    base = {"operation": Operation.GENERATE, "target_type": MediaType.VIDEO, "prompt": "test"}
+    base = {
+        "operation": Operation.GENERATE,
+        "target_type": MediaType.VIDEO,
+        "prompt": "test",
+    }
     base.update(kw)
     return GenerationRequest(**base)
 
 
 class TestMiniMaxH3LocalT2V:
     def test_metadata(self):
-        a = MiniMaxH3LocalT2VAdapter()
+        a = minimax_h3_t2v.MiniMaxH3LocalT2VAdapter()
         assert a.name == "minimax-h3-local-t2v"
         assert a.model_family == "minimax_h3"
         assert Operation.GENERATE in a.supported_ops
@@ -58,7 +62,7 @@ class TestMiniMaxH3LocalT2V:
         assert a.lora_format == LoraFormat.SINGLE_STAGE
 
     def test_constraints(self):
-        c = MiniMaxH3LocalT2VAdapter().constraints()
+        c = minimax_h3_t2v.MiniMaxH3LocalT2VAdapter().constraints()
         assert c.max_frames == 362
         assert c.default_steps == 20
         assert c.default_cfg == 1.0
@@ -66,17 +70,27 @@ class TestMiniMaxH3LocalT2V:
         assert c.supports_negative_prompt is False
         assert "16:9" in c.aspect_ratios
 
-    @pytest.mark.parametrize("frames,expected", [
-        (124, 8), (210, 12), (362, 15),
-    ])
+    @pytest.mark.parametrize(
+        "frames,expected",
+        [
+            (124, 8),
+            (210, 12),
+            (362, 15),
+        ],
+    )
     def test_cost(self, frames, expected):
-        assert MiniMaxH3LocalT2VAdapter().cost(_req(frames=frames)) == expected
+        assert (
+            minimax_h3_t2v.MiniMaxH3LocalT2VAdapter().cost(_req(frames=frames))
+            == expected
+        )
 
     def test_build_workflow_delegates_to_local_builder(self):
         mock = MagicMock()
         mock.build_local_minimax_h3_t2v_workflow.return_value = {"h3": "wf"}
-        a = MiniMaxH3LocalT2VAdapter(comfyui_client_fn=lambda: mock)
-        req = _req(frames=124, fps=24, seed=5, steps=20, aspect_ratio="16:9", megapixels=0.98)
+        a = minimax_h3_t2v.MiniMaxH3LocalT2VAdapter(comfyui_client_fn=lambda: mock)
+        req = _req(
+            frames=124, fps=24, seed=5, steps=20, aspect_ratio="16:9", megapixels=0.98
+        )
         wf = a.build_workflow(req)
         assert wf == {"h3": "wf"}
         mock.build_local_minimax_h3_t2v_workflow.assert_called_once()
@@ -90,11 +104,13 @@ class TestMiniMaxH3LocalT2V:
     def test_build_workflow_passes_loras(self):
         mock = MagicMock()
         mock.build_local_minimax_h3_t2v_workflow.return_value = {"h3": "wf"}
-        a = MiniMaxH3LocalT2VAdapter(comfyui_client_fn=lambda: mock)
+        a = minimax_h3_t2v.MiniMaxH3LocalT2VAdapter(comfyui_client_fn=lambda: mock)
         req = _req(loras=[LoraStackItem(name="bounce.safetensors", strength=0.8)])
         a.build_workflow(req)
         kwargs = mock.build_local_minimax_h3_t2v_workflow.call_args[1]
-        assert kwargs["lora_configs"] == [{"name": "bounce.safetensors", "strength": 0.8}]
+        assert kwargs["lora_configs"] == [
+            {"name": "bounce.safetensors", "strength": 0.8}
+        ]
 
     @pytest.mark.asyncio
     async def test_execute_uploads_loras_before_queue(self):
@@ -104,9 +120,8 @@ class TestMiniMaxH3LocalT2V:
         mock.upload_lora.return_value = "bounce.safetensors"
         mock.host = "windows-comfy.test.internal"
         mock.port = 8188
-        import generation.adapters.local.minimax_h3_t2v as mod
-        mod._MINIMAX_H3_LORA_DIR = mod.Path("/definitely/missing/dir")
-        a = MiniMaxH3LocalT2VAdapter(comfyui_client_fn=lambda: mock)
+        minimax_h3_t2v._MINIMAX_H3_LORA_DIR = Path("/definitely/missing/dir")
+        a = minimax_h3_t2v.MiniMaxH3LocalT2VAdapter(comfyui_client_fn=lambda: mock)
         req = _req(loras=[LoraStackItem(name="missing.safetensors", strength=0.8)])
         await a.execute(req)
         # missing lora file -> skipped, upload never called, but job still runs
@@ -120,7 +135,7 @@ class TestMiniMaxH3LocalT2V:
         mock.queue_prompt.return_value = "p123"
         mock.host = "windows-comfy.test.internal"
         mock.port = 8188
-        a = MiniMaxH3LocalT2VAdapter(comfyui_client_fn=lambda: mock)
+        a = minimax_h3_t2v.MiniMaxH3LocalT2VAdapter(comfyui_client_fn=lambda: mock)
         req = _req(frames=124)
         res = await a.execute(req)
         assert res.status == "queued_local"
@@ -132,20 +147,20 @@ class TestMiniMaxH3LocalT2V:
     async def test_execute_raises_when_server_down(self):
         mock = MagicMock()
         mock.is_available.return_value = False
-        a = MiniMaxH3LocalT2VAdapter(comfyui_client_fn=lambda: mock)
+        a = minimax_h3_t2v.MiniMaxH3LocalT2VAdapter(comfyui_client_fn=lambda: mock)
         with pytest.raises(RuntimeError):
             await a.execute(_req())
 
     @pytest.mark.asyncio
     async def test_execute_raises_when_backend_unresolved(self):
-        a = MiniMaxH3LocalT2VAdapter(comfyui_client_fn=lambda: None)
+        a = minimax_h3_t2v.MiniMaxH3LocalT2VAdapter(comfyui_client_fn=lambda: None)
         with pytest.raises(RuntimeError, match="No enabled local ComfyUI backend"):
             await a.execute(_req())
 
 
 class TestMiniMaxH3LocalI2V:
     def test_metadata(self):
-        a = MiniMaxH3LocalI2VAdapter()
+        a = minimax_h3_i2v.MiniMaxH3LocalI2VAdapter()
         assert a.name == "minimax-h3-local-i2v"
         assert a.compute == ComputeTarget.LOCAL
         assert MediaType.IMAGE in a.input_types
@@ -153,16 +168,24 @@ class TestMiniMaxH3LocalI2V:
         assert a.handles_own_image_upload is True
 
     def test_constraints(self):
-        c = MiniMaxH3LocalI2VAdapter().constraints()
+        c = minimax_h3_i2v.MiniMaxH3LocalI2VAdapter().constraints()
         assert c.max_input_images == 1
         assert c.allowed_fps == [24]
         assert c.supports_negative_prompt is False
 
-    @pytest.mark.parametrize("frames,expected", [
-        (124, 5), (210, 8), (362, 15),
-    ])
+    @pytest.mark.parametrize(
+        "frames,expected",
+        [
+            (124, 5),
+            (210, 8),
+            (362, 15),
+        ],
+    )
     def test_cost(self, frames, expected):
-        assert MiniMaxH3LocalI2VAdapter().cost(_req(frames=frames)) == expected
+        assert (
+            minimax_h3_i2v.MiniMaxH3LocalI2VAdapter().cost(_req(frames=frames))
+            == expected
+        )
 
     @pytest.mark.asyncio
     async def test_execute_uploads_to_windows_client(self):
@@ -172,7 +195,7 @@ class TestMiniMaxH3LocalI2V:
         mock.queue_prompt.return_value = "p456"
         mock.host = "windows-comfy.test.internal"
         mock.port = 8188
-        a = MiniMaxH3LocalI2VAdapter(comfyui_client_fn=lambda: mock)
+        a = minimax_h3_i2v.MiniMaxH3LocalI2VAdapter(comfyui_client_fn=lambda: mock)
         req = _req(input_images=[_png_b64()], frames=124)
         res = await a.execute(req)
         assert res.status == "queued_local"
@@ -181,17 +204,22 @@ class TestMiniMaxH3LocalI2V:
         mock.upload_image_from_bytes.assert_called_once()
         # and the workflow built with the returned filename
         mock.build_local_minimax_h3_i2v_workflow.assert_called_once()
-        assert mock.build_local_minimax_h3_i2v_workflow.call_args[1]["image_name"] == "v2_minimax_i2v_input.png"
+        assert (
+            mock.build_local_minimax_h3_i2v_workflow.call_args[1]["image_name"]
+            == "v2_minimax_i2v_input.png"
+        )
 
     @pytest.mark.asyncio
     async def test_execute_requires_image(self):
-        a = MiniMaxH3LocalI2VAdapter(comfyui_client_fn=lambda: MagicMock())
+        a = minimax_h3_i2v.MiniMaxH3LocalI2VAdapter(
+            comfyui_client_fn=lambda: MagicMock()
+        )
         with pytest.raises(ValueError):
             await a.execute(_req())
 
     @pytest.mark.asyncio
     async def test_execute_raises_when_backend_unresolved(self):
-        a = MiniMaxH3LocalI2VAdapter(comfyui_client_fn=lambda: None)
+        a = minimax_h3_i2v.MiniMaxH3LocalI2VAdapter(comfyui_client_fn=lambda: None)
         with pytest.raises(RuntimeError, match="No enabled local ComfyUI backend"):
             await a.execute(_req(input_images=[_png_b64()]))
 
@@ -200,7 +228,7 @@ class TestMiniMaxH3LocalI2V:
         mock = MagicMock()
         mock.is_available.return_value = True
         mock.upload_image_from_bytes.return_value = None
-        a = MiniMaxH3LocalI2VAdapter(comfyui_client_fn=lambda: mock)
+        a = minimax_h3_i2v.MiniMaxH3LocalI2VAdapter(comfyui_client_fn=lambda: mock)
         req = _req(input_images=[_png_b64()])
         with pytest.raises(RuntimeError):
             await a.execute(req)

--- a/tests/test_local_minimax_h3.py
+++ b/tests/test_local_minimax_h3.py
@@ -102,7 +102,7 @@ class TestMiniMaxH3LocalT2V:
         mock.is_available.return_value = True
         mock.queue_prompt.return_value = "p123"
         mock.upload_lora.return_value = "bounce.safetensors"
-        mock.host = "192.168.1.245"
+        mock.host = "windows-comfy.test.internal"
         mock.port = 8188
         import generation.adapters.local.minimax_h3_t2v as mod
         mod._MINIMAX_H3_LORA_DIR = mod.Path("/definitely/missing/dir")
@@ -118,7 +118,7 @@ class TestMiniMaxH3LocalT2V:
         mock = MagicMock()
         mock.is_available.return_value = True
         mock.queue_prompt.return_value = "p123"
-        mock.host = "192.168.1.245"
+        mock.host = "windows-comfy.test.internal"
         mock.port = 8188
         a = MiniMaxH3LocalT2VAdapter(comfyui_client_fn=lambda: mock)
         req = _req(frames=124)
@@ -170,7 +170,7 @@ class TestMiniMaxH3LocalI2V:
         mock.is_available.return_value = True
         mock.upload_image_from_bytes.return_value = "v2_minimax_i2v_input.png"
         mock.queue_prompt.return_value = "p456"
-        mock.host = "192.168.1.245"
+        mock.host = "windows-comfy.test.internal"
         mock.port = 8188
         a = MiniMaxH3LocalI2VAdapter(comfyui_client_fn=lambda: mock)
         req = _req(input_images=[_png_b64()], frames=124)

--- a/tests/test_local_minimax_h3.py
+++ b/tests/test_local_minimax_h3.py
@@ -211,7 +211,9 @@ class TestMiniMaxH3LocalI2V:
 
     @pytest.mark.asyncio
     async def test_execute_requires_image(self):
-        a = minimax_h3_i2v.MiniMaxH3LocalI2VAdapter(comfyui_client_fn=MagicMock)
+        mock = MagicMock()
+        mock.is_available.return_value = True
+        a = minimax_h3_i2v.MiniMaxH3LocalI2VAdapter(comfyui_client_fn=lambda: mock)
         with pytest.raises(ValueError):
             await a.execute(_req())
 


### PR DESCRIPTION
## Summary

Adds LoRA support for the **local** MiniMax-H3 (`minimax-h3-local-t2v` / `minimax-h3-local-i2v`) adapters that run on the user's Windows-PC ComfyUI.

## What changed

- **Workflow builders** (`comfyui_client.py`): `_build_minimax_h3_workflow()` now chains single-stage `LoraLoaderModelOnly` nodes in front of the base `UNETLoader` and re-points the BasicGuider (node 6) + BasicScheduler (node 8) at the last loader. All `build_cloud_minimax_h3_*` / `build_local_minimax_h3_*` builders accept an optional `lora_configs=[{name, strength}, ...]`.
- **Local adapters**: `MiniMaxH3LocalT2VAdapter` / `MiniMaxH3LocalI2VAdapter` pass `req.loras` (single-stage `{name, strength}`) into the builders and upload each requested LoRA from `/mnt/ssd/loras/minimax-h3` to the Windows-PC ComfyUI before dispatch via a new `ComfyUIClient.upload_lora()` (`/internal/models/upload`, `type=loras`). Missing/unfounded LoRAs are warned & skipped, not fatal.
- **LoRA scanner**: `_derive_base_model()` now recognises `minimax_h3` (subdir `minimax-h3/`, markers `minimax` / `fl2va`) so MiniMax-H3 LoRAs aren't mis-labelled `wan2.2`.
- **LoRA registry** (`docs/lora_registry.yaml`): added the three MiniMax-H3 LoRAs — `bounceV07_fl2va-000230_Intense`, `PenisV2_minimax-h3_epoch60`, `Vagina_minimax-h3_epoch20` (base_model `minimax_h3`, modes t2v+i2v).
- **Frontend** (`TextToVideoTool.jsx`): the LoRA panel is now shown for the local MiniMax-H3 mode (`minimax_h3_local`); it stays hidden for the cloud worker (`minimax_h3`), which has no LoRA support yet.

## Tests

- New `tests/test_comfyui_minimax_h3_lora.py` — verifies LoRA node injection (single + chained multi), no node-id collisions with the image/output nodes, and base-model link preservation when no LoRAs are present.
- Extended `tests/test_local_minimax_h3.py` — LoRA delegation in `build_workflow` / `execute`.
- `lora_scanner` base-model derivation covered.
- `ruff` clean on all changed files; backend + frontend rebuilt and redeployed; verified the 3 LoRAs appear in `/api/loras?base_model=minimax_h3`.