### PR TITLE
refactor(compute): generalized named compute node types (drop legacy windows path)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,13 +68,34 @@ RUNPOD_LORA_S3_ENDPOINT=https://s3api-eu-cz-1.runpod.io
 RUNPOD_MINIMAX_H3_ENDPOINT_ID=your-minimax-h3-endpoint-id
 RUNPOD_MINIMAX_H3_TEMPLATE_ID=your-minimax-h3-template-id
 
-# Local MiniMax-H3 (Windows PC ComfyUI) — a SECOND ComfyUI server, separate
-# from the one on ai-kvm2 (get_comfyui_client). MiniMax-H3 local generation is
-# routed here because the H3 models + workflow live on the Windows machine
-# (ComfyUI portable). Leave COMFYUI_WINDOWS_HOST empty to disable local H3.
-# (see README_MiniMax_H3_workflow.md)
-COMFYUI_WINDOWS_HOST=windows-pc.test.invalid
-COMFYUI_WINDOWS_PORT=8188
+# ── Compute Nodes (fresh-install fallback inventory) ──────────────────
+# The Admin panel → Compute (compute_backends.json) is the source of truth for
+# which compute servers exist and which model families each one runs. The
+# COMPUTE_NODE_n_* groups below are only the built-in fallback used on a fresh
+# install before the first Admin save; keep them in sync with the servers you
+# actually run. Each group declares one node:
+#   TYPE=comfy|runpod — 'comfy': a hosted/desktop ComfyUI reachable by
+#                       HOST:PORT; 'runpod': a serverless RunPod container
+#                       (endpoint IDs stay under RUNPOD_* above, no HOST).
+#   HOST / PORT       — address of a 'comfy' node (PORT optional, default 8188).
+#   NAME              — display name for the node.
+#   MODEL_FAMILIES    — comma-separated model families this node can run.
+# Node numbers must be contiguous (COMPUTE_NODE_1..N); the scan stops at the
+# first gap. Never commit real private addresses — use placeholders here.
+COMPUTE_NODE_1_TYPE=comfy
+COMPUTE_NODE_1_HOST=localhost
+COMPUTE_NODE_1_PORT=8188
+COMPUTE_NODE_1_NAME=ai-kvm2 ComfyUI (local)
+COMPUTE_NODE_1_MODEL_FAMILIES=wan2.2,sdxl,flux,flux2,krea2,utility
+
+COMPUTE_NODE_2_TYPE=comfy
+COMPUTE_NODE_2_HOST=windows-pc.test.invalid
+COMPUTE_NODE_2_NAME=Windows-PC ComfyUI
+COMPUTE_NODE_2_MODEL_FAMILIES=minimax_h3
+
+COMPUTE_NODE_3_TYPE=runpod
+COMPUTE_NODE_3_NAME=RunPod serverless
+COMPUTE_NODE_3_MODEL_FAMILIES=wan2.2,ltx,minimax_h3,qwen_image_edit,i2i_edit_model
 
 # Google OAuth (configured in Supabase dashboard, not needed here)
 # GOOGLE_CLIENT_ID=xxx.apps.googleusercontent.com

--- a/.goosehints
+++ b/.goosehints
@@ -19,13 +19,16 @@ source of truth.
 - **Frontend** — React 18 + Vite 7, **JSX only** (67 `.jsx`, 0 `.tsx`) in `src/frontend/src/`
   (port 5174). Supabase, Sentry, Recharts. Always use `apiFetch()` from `utils/api.ts`, never raw `fetch()`.
 - **Execution / compute** — modular *compute backends*, each a configurable source that can run
-  certain model families (see `src/backend/generation/compute_backends.py` + `compute_backends.json`):
+  certain model families. The backend inventory (see `src/backend/generation/compute_backends.py` +
+  `compute_backends.json`, editable via the Admin panel → "Compute") is the **source of truth**;
+  the `COMPUTE_NODE_*` env schema in `.env` is only the fresh-install fallback. Backend types are an
+  extensible enum: `comfyui` (any hosted/desktop ComfyUI reachable by `base_url`) and `runpod`
+  (serverless container submitted via the RunPod client):
   - **ai-kvm2 local ComfyUI** — `localhost:8188` (default client, workflows in `workflows/`,
     models in `ComfyUI/models/`), DisTorch2 multi-GPU alloc `cuda:0,10gb;cuda:1,15gb;cpu,*` with
     **RTX 3060 first**. Managed by systemd `comfyui`; **`always_on`** (monifuse must not idle-stop it).
-  - **Windows-PC ComfyUI** — a second server (hosts local MiniMax-H3). Configured
-    via `COMFYUI_WINDOWS_HOST`/`COMFYUI_WINDOWS_PORT` in `.env`; accessed through
-    `get_windows_comfyui_client()`.
+  - **Second ComfyUI server** (e.g. a Windows-PC) — hosts local MiniMax-H3; resolved purely through
+    the inventory like any other `comfyui` backend (no bespoke `get_windows_comfyui_client`).
   - **RunPod cloud** — headless = a container with an ephemeral ComfyUI server (Wan2.2, LTX-2.3,
     MiniMax-H3, Qwen I2I). Submit via `submit_to_runpod_fn`.
   Adapters live in `src/backend/generation/adapters/{cloud,local}/`; the registry + router resolve

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,13 +19,16 @@ source of truth.
 - **Frontend** — React 18 + Vite 7, **JSX only** (67 `.jsx`, 0 `.tsx`) in `src/frontend/src/`
   (port 5174). Supabase, Sentry, Recharts. Always use `apiFetch()` from `utils/api.ts`, never raw `fetch()`.
 - **Execution / compute** — modular *compute backends*, each a configurable source that can run
-  certain model families (see `src/backend/generation/compute_backends.py` + `compute_backends.json`):
+  certain model families. The backend inventory (see `src/backend/generation/compute_backends.py` +
+  `compute_backends.json`, editable via the Admin panel → "Compute") is the **source of truth**;
+  the `COMPUTE_NODE_*` env schema in `.env` is only the fresh-install fallback. Backend types are an
+  extensible enum: `comfyui` (any hosted/desktop ComfyUI reachable by `base_url`) and `runpod`
+  (serverless container submitted via the RunPod client):
   - **ai-kvm2 local ComfyUI** — `localhost:8188` (default client, workflows in `workflows/`,
     models in `ComfyUI/models/`), DisTorch2 multi-GPU alloc `cuda:0,10gb;cuda:1,15gb;cpu,*` with
     **RTX 3060 first**. Managed by systemd `comfyui`; **`always_on`** (monifuse must not idle-stop it).
-  - **Windows-PC ComfyUI** — a second server (hosts local MiniMax-H3). Configured
-    via `COMFYUI_WINDOWS_HOST`/`COMFYUI_WINDOWS_PORT` in `.env`; accessed through
-    `get_windows_comfyui_client()`.
+  - **Second ComfyUI server** (e.g. a Windows-PC) — hosts local MiniMax-H3; resolved purely through
+    the inventory like any other `comfyui` backend (no bespoke `get_windows_comfyui_client`).
   - **RunPod cloud** — headless = a container with an ephemeral ComfyUI server (Wan2.2, LTX-2.3,
     MiniMax-H3, Qwen I2I). Submit via `submit_to_runpod_fn`.
   Adapters live in `src/backend/generation/adapters/{cloud,local}/`; the registry + router resolve

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,13 +19,16 @@ source of truth.
 - **Frontend** — React 18 + Vite 7, **JSX only** (67 `.jsx`, 0 `.tsx`) in `src/frontend/src/`
   (port 5174). Supabase, Sentry, Recharts. Always use `apiFetch()` from `utils/api.ts`, never raw `fetch()`.
 - **Execution / compute** — modular *compute backends*, each a configurable source that can run
-  certain model families (see `src/backend/generation/compute_backends.py` + `compute_backends.json`):
+  certain model families. The backend inventory (see `src/backend/generation/compute_backends.py` +
+  `compute_backends.json`, editable via the Admin panel → "Compute") is the **source of truth**;
+  the `COMPUTE_NODE_*` env schema in `.env` is only the fresh-install fallback. Backend types are an
+  extensible enum: `comfyui` (any hosted/desktop ComfyUI reachable by `base_url`) and `runpod`
+  (serverless container submitted via the RunPod client):
   - **ai-kvm2 local ComfyUI** — `localhost:8188` (default client, workflows in `workflows/`,
     models in `ComfyUI/models/`), DisTorch2 multi-GPU alloc `cuda:0,10gb;cuda:1,15gb;cpu,*` with
     **RTX 3060 first**. Managed by systemd `comfyui`; **`always_on`** (monifuse must not idle-stop it).
-  - **Windows-PC ComfyUI** — a second server (hosts local MiniMax-H3). Configured
-    via `COMFYUI_WINDOWS_HOST`/`COMFYUI_WINDOWS_PORT` in `.env`; accessed through
-    `get_windows_comfyui_client()`.
+  - **Second ComfyUI server** (e.g. a Windows-PC) — hosts local MiniMax-H3; resolved purely through
+    the inventory like any other `comfyui` backend (no bespoke `get_windows_comfyui_client`).
   - **RunPod cloud** — headless = a container with an ephemeral ComfyUI server (Wan2.2, LTX-2.3,
     MiniMax-H3, Qwen I2I). Submit via `submit_to_runpod_fn`.
   Adapters live in `src/backend/generation/adapters/{cloud,local}/`; the registry + router resolve

--- a/README_MiniMax_H3_workflow.md
+++ b/README_MiniMax_H3_workflow.md
@@ -17,7 +17,8 @@ text-encoder aangepast naar de **int8_convrot** variant die op de server staat
 ## Openen
 
 - **In de browser (aanbevolen)** — server draait al met alle modellen op schijf:
-  `http://COMFYUI_WINDOWS_HOST:8188` → sleep het .json op het canvas (of Workflow → Open).
+  `http://COMPUTE_NODE_2_HOST:8188` (de remote ComfyUI node die minimax_h3 draait) → sleep
+  het .json op het canvas (of Workflow → Open).
 - **In Comfy Desktop:** Workflow-menu → Open → dit bestand.
 
 ## Belangrijk — waar Desktop z'n modellen vandaan haalt

--- a/changelog/189-compute-node-types.md
+++ b/changelog/189-compute-node-types.md
@@ -1,0 +1,33 @@
+# Compute node types — generalized compute backend config
+
+## Added
+
+- `COMPUTE_NODE_{n}_*` env schema as the fresh-install fallback inventory:
+  `TYPE` (`comfy` | `runpod`, extensible enum with `comfyui` accepted as an
+  alias), `HOST` + optional `PORT` (default 8188) for `comfy` nodes,
+  `NAME` display label, and `MODEL_FAMILIES` comma-list. Liked fallback nodes
+  keep deterministic ids `node-{n}`; the scan stops at the first gap and
+  invalid groups are skipped with a warning.
+
+## Changed
+
+- The Compute Backend Inventory (`compute_backends.py`, Admin panel → Compute)
+  is now the single source of truth for which servers run which model families;
+  env vars are only the fallback when `compute_backends.json` is missing.
+- Removed the bespoke Windows client path:
+  `get_windows_comfyui_client()` and the `COMFYUI_WINDOWS_HOST` /
+  `COMFYUI_WINDOWS_PORT` env vars. A second server (e.g. a Windows PC running
+  local MiniMax-H3) is now just another `comfyui` backend resolved through the
+  inventory (`get_comfyui_client_for_backend`).
+- Queue indicator / job-result resolution now poll the actual backend a local
+  job is tagged with (by `backend_id`) instead of a hardcoded Windows branch;
+  the frontend `server` label shows the backend name.
+- Docs (`AGENTS.md`, `docs/COMFYUI_INVENTORY.md`, `docs/GENERATION_MODES.md`,
+  `README_MiniMax_H3_workflow.md`) and adapter docstrings reworded to generic
+  "compute node" language; `.env.example` documents the new schema.
+
+## Notes
+
+- No hardcoded addresses anywhere: `.env.example` and
+  `compute_backends.json.example` use placeholders (`windows-pc.test.invalid`),
+  and tests use dummy hosts.

--- a/docs/COMFYUI_INVENTORY.md
+++ b/docs/COMFYUI_INVENTORY.md
@@ -175,22 +175,25 @@ Compute op `cuda:1`, ~7.2GB model naar CPU-offload. De compute-kaart NIET >75% v
 
 ---
 
-## 🪟 Windows-PC ComfyUI (tweede server — lokale MiniMax-H3)
+## 🖥️ Tweede ComfyUI-server (remote compute node — lokale MiniMax-H3)
 
-Naast de ComfyUI op **ai-kvm2** (`localhost:8188`, systemd `comfyui`) is er een **tweede
-ComfyUI-server op de Windows-PC van de user** waarop lokale MiniMax-H3 draait.
+Naast de ComfyUI op **ai-kvm2** (`localhost:8188`, systemd `comfyui`) kan er een **tweede
+ComfyUI-server** zijn (bijv. de Windows-PC van de user) waarop lokale MiniMax-H3 draait. Die
+wordt, net als elke andere `comfyui` backend, geconfigureerd via de compute backend inventory
+(Admin panel → Compute) of de `COMPUTE_NODE_*` env-fallback — er is geen aparte server-client
+meer.
 
 | Eigenschap | Waarde |
 |-----------|--------|
-| Host | `COMFYUI_WINDOWS_HOST` (set in `.env`) |
-| Poort (default) | `8188` (`COMFYUI_WINDOWS_PORT`) |
+| Host | `base_url` in `compute_backends.json` / `COMPUTE_NODE_{n}_HOST` (fallback) |
+| Poort (default) | `8188` |
 | Installatie | ComfyUI portable (`C:\PROGRAMME\ComfyUI_windows_portable`) |
 | Draaiend via | Taak `ComfyUIServer` bij inloggen (`start_comfy_server.bat`, log `comfy_server.log`) |
-| Backend-client | `get_windows_comfyui_client()` in `comfyui_client.py` |
+| Backend-client | `get_comfyui_client_for_backend()` (inventory) in `comfyui_client.py` |
 
 Lokale MiniMax-H3 adapters (`minimax-h3-local-t2v` / `-i2v`) worden alleen geregistreerd
-wanneer `COMFYUI_WINDOWS_HOST` is gezet. De I2V-variant uploadt z'n input-image zelf naar
-deze server (`handles_own_image_upload=True`).
+wanneer er een enabled `comfyui` backend is die `minimax_h3` declareert. De I2V-variant
+uploadt z'n input-image zelf naar deze server (`handles_own_image_upload=True`).
 
 ### MiniMax-H3 local modellen (Windows PC)
 

--- a/docs/GENERATION_MODES.md
+++ b/docs/GENERATION_MODES.md
@@ -81,8 +81,10 @@ This document provides a comprehensive overview of all available generation mode
 | **Video VAE** | `minimax_h3_video_vae_fp16.safetensors` | `vae/` |
 | **Audio VAE** | `minimax_h3_audio_vae_fp32.safetensors` | `vae/` |
 
-Lokaal draait MiniMax-H3 op de **Windows-PC ComfyUI** (`COMFYUI_WINDOWS_HOST`, set via `COMFYUI_WINDOWS_HOST`)
-— een tweede ComfyUI-server naast die op ai-kvm2. De int8_convrot text-encoder past in 16GB VRAM
+Lokaal draait MiniMax-H3 op een **tweede ComfyUI-server** (remote compute node, bijv. de
+Windows-PC) — geconfigureerd via de compute backend inventory (`COMPUTE_NODE_{n}_HOST` in `.env`
+als fresh-install fallback; Admin panel → Compute als bron van waarheid). De int8_convrot
+text-encoder past in 16GB VRAM
 (zie `README_MiniMax_H3_workflow.md` en `download_minimax_h3.*`).
 
 ### T2V Alternative Models (Untested/Experimental)

--- a/src/backend/app.py
+++ b/src/backend/app.py
@@ -173,7 +173,6 @@ try:
     from src.backend.comfyui_client import (
         ComfyUIClient,
         get_comfyui_client,
-        get_windows_comfyui_client,
     )
 
     print("✅ ComfyUIClient imported successfully")
@@ -181,7 +180,6 @@ except ImportError as e:
     print(f"❌ Failed to import ComfyUIClient: {e}")
     ComfyUIClient = None
     get_comfyui_client = None
-    get_windows_comfyui_client = None
 
 # WebSocket progress tracking
 try:
@@ -2976,10 +2974,9 @@ async def _resolve_local_job_result(prompt_id: str, job_info: dict) -> Optional[
     if cached is not None:
         return cached
 
-    # Resolve the ComfyUI client that actually ran the job. Prefer the
-    # backend_id attached at dispatch (config-driven via the compute backend
-    # inventory, e.g. Windows-PC for MiniMax-H3), falling back to the legacy
-    # adapter-name check.
+    # Resolve the ComfyUI client that actually ran the job. The backend_id
+    # attached at dispatch drives it via the compute backend inventory (any
+    # enabled comfyui backend, e.g. a second server running MiniMax-H3).
     adapter_name = job_info.get("adapter_name", "")
     backend_id = job_info.get("backend_id")
     comfyui = None
@@ -3004,12 +3001,6 @@ async def _resolve_local_job_result(prompt_id: str, job_info: dict) -> Optional[
                 exc_info=True,
             )
             comfyui = None
-    is_windows_h3 = adapter_name in (
-        "minimax-h3-local-t2v",
-        "minimax-h3-local-i2v",
-    )
-    if comfyui is None and is_windows_h3 and get_windows_comfyui_client is not None:
-        comfyui = get_windows_comfyui_client()
     if comfyui is None:
         comfyui = get_comfyui_client()
     if comfyui is None:
@@ -3070,8 +3061,8 @@ async def _resolve_local_job_result(prompt_id: str, job_info: dict) -> Optional[
 
     # If the video was found as an output record (SaveVideo / VHS), try to
     # download it from the job's ComfyUI server so we have a local file to
-    # upload. For Windows-PC (H3 local) the file is NOT on ai-kvm2, so this
-    # download is required.
+    # upload. For a remote compute backend (e.g. MiniMax-H3 on a second
+    # server) the file is NOT on ai-kvm2, so this download is required.
     if output_video and isinstance(output_video, dict):
         vf = output_video.get("filename")
         output_filename = _safe_filename(vf) if vf else None
@@ -4140,71 +4131,83 @@ async def get_comfyui_queue(user: Optional[User] = Depends(get_optional_user)):
                 job_info.update(active_job)
                 pending.append(job_info)
 
-        # ── Windows-PC ComfyUI (remote MiniMax-H3) queue ─────────────────
-        # H3 local jobs run on the remote Windows-PC ComfyUI, NOT on the
-        # ai-kvm2 localhost server. Surface them in the queue indicator as
-        # running/pending so the user sees remote jobs alongside local/cloud
-        # ones.
-        windows_running = []
-        windows_pending = []
-        if get_windows_comfyui_client is not None:
-            try:
-                wclient = get_windows_comfyui_client()
-                if wclient is not None:
-                    wq_resp = requests.get(f"{wclient.base_url}/queue", timeout=5)
-                    if wq_resp.status_code == 200:
-                        wq = wq_resp.json()
-                        # Which of this user's active jobs live on the Windows server?
-                        windows_local = {
-                            pid: info
-                            for pid, info in active_jobs.items()
-                            if info.get("user_id") == user.id
-                            and info.get("adapter_name")
-                            in ("minimax-h3-local-t2v", "minimax-h3-local-i2v")
-                        }
-                        seen = set()
-                        for item in wq.get("queue_running", []):
-                            if len(item) >= 2:
-                                pid = item[1]
-                                if pid not in windows_local:
-                                    continue
-                                seen.add(pid)
-                                job_info = {
-                                    "prompt_id": pid,
-                                    "status": "running",
-                                    "queue_position": 0,
-                                    "server": "windows",
-                                }
-                                job_info.update(windows_local[pid])
-                                windows_running.append(job_info)
-                        for idx, item in enumerate(wq.get("queue_pending", [])):
-                            if len(item) >= 2:
-                                pid = item[1]
-                                if pid not in windows_local:
-                                    continue
-                                seen.add(pid)
-                                job_info = {
-                                    "prompt_id": pid,
-                                    "status": "pending",
-                                    "queue_position": idx + 1,
-                                    "server": "windows",
-                                }
-                                job_info.update(windows_local[pid])
-                                windows_pending.append(job_info)
-                        # Windows-local jobs tracked locally but no longer on
-                        # Windows queue → treat as pending (still to be freed).
-                        for pid in windows_local:
-                            if pid not in seen:
-                                job_info = {
-                                    "prompt_id": pid,
-                                    "status": "pending",
-                                    "queue_position": 0,
-                                    "server": "windows",
-                                }
-                                job_info.update(windows_local[pid])
-                                windows_pending.append(job_info)
-            except Exception as e:
-                logger.warning(f"⚠️ Failed to get Windows ComfyUI queue: {e}")
+        # ── Remote ComfyUI backends (compute node inventory) ──────────────
+        # Local jobs may run on any enabled 'comfyui' backend from the compute
+        # inventory (e.g. a second server running MiniMax-H3), not just the
+        # ai-kvm2 default server. Surface each backend this user's active local
+        # jobs are tagged with in the queue indicator alongside local/cloud
+        # ones. The default server is already polled above, so backends whose
+        # resolved client equals it are skipped.
+        remote_running = []
+        remote_pending = []
+        try:
+            from src.backend.comfyui_client import get_comfyui_client_for_backend
+            from src.backend.generation.compute_backends import get_backend
+
+            default_base = get_comfyui_client().base_url
+            # Group this user's active local (non-cloud) jobs by backend.
+            by_backend: dict = {}
+            for pid, info in active_jobs.items():
+                if info.get("user_id") != user.id:
+                    continue
+                if info.get("compute_target") == "cloud":
+                    continue
+                bid = info.get("backend_id")
+                if bid:
+                    by_backend.setdefault(bid, {})[pid] = info
+
+            if by_backend:
+                for bid, jobs in by_backend.items():
+                    backend = get_backend(bid)
+                    if backend is None or backend.type != "comfyui":
+                        continue
+                    client = get_comfyui_client_for_backend(backend)
+                    if client is None or client.base_url == default_base:
+                        # Resolves to the default server — polled above.
+                        continue
+                    queue_resp = requests.get(f"{client.base_url}/queue", timeout=5)
+                    if queue_resp.status_code != 200:
+                        continue
+                    queue = queue_resp.json()
+                    seen = set()
+                    for item in queue.get("queue_running", []):
+                        if len(item) >= 2 and item[1] in jobs:
+                            pid = item[1]
+                            seen.add(pid)
+                            job_info = {
+                                "prompt_id": pid,
+                                "status": "running",
+                                "queue_position": 0,
+                                "server": backend.name,
+                            }
+                            job_info.update(jobs[pid])
+                            remote_running.append(job_info)
+                    for idx, item in enumerate(queue.get("queue_pending", [])):
+                        if len(item) >= 2 and item[1] in jobs:
+                            pid = item[1]
+                            seen.add(pid)
+                            job_info = {
+                                "prompt_id": pid,
+                                "status": "pending",
+                                "queue_position": idx + 1,
+                                "server": backend.name,
+                            }
+                            job_info.update(jobs[pid])
+                            remote_pending.append(job_info)
+                    # Locally tracked jobs no longer on this backend's queue →
+                    # treat as pending (still to be released).
+                    for pid in jobs:
+                        if pid not in seen:
+                            job_info = {
+                                "prompt_id": pid,
+                                "status": "pending",
+                                "queue_position": 0,
+                                "server": backend.name,
+                            }
+                            job_info.update(jobs[pid])
+                            remote_pending.append(job_info)
+        except Exception as e:
+            logger.warning(f"⚠️ Failed to poll remote ComfyUI backends: {e}")
 
         # Include face LoRA training jobs in the queue
         training = []
@@ -4291,8 +4294,8 @@ async def get_comfyui_queue(user: Optional[User] = Depends(get_optional_user)):
                 cloud_job["status"] = "running"
                 cloud_running.append(cloud_job)
 
-        all_running = running + cloud_running + windows_running
-        all_pending = pending + windows_pending
+        all_running = running + cloud_running + remote_running
+        all_pending = pending + remote_pending
 
         return {
             "running": all_running,

--- a/src/backend/comfyui_client.py
+++ b/src/backend/comfyui_client.py
@@ -5846,11 +5846,6 @@ WAN22_I2V_DISTORCH2_API_WORKFLOW = {
 # Singleton instance
 _comfyui_client: Optional[ComfyUIClient] = None
 
-# Optional second ComfyUI server — the user's Windows PC (used for local
-# MiniMax-H3 generation, which runs on that machine's ComfyUI rather than the
-# one on ai-kvm2). Configured via COMFYUI_WINDOWS_HOST / COMFYUI_WINDOWS_PORT.
-_windows_comfyui_client: Optional[ComfyUIClient] = None
-
 
 def get_comfyui_client() -> ComfyUIClient:
     """Get or create ComfyUI client singleton"""
@@ -5860,39 +5855,13 @@ def get_comfyui_client() -> ComfyUIClient:
     return _comfyui_client
 
 
-def get_windows_comfyui_client() -> Optional[ComfyUIClient]:
-    """Get/create the ComfyUI client for the user's Windows PC.
-
-    This is a separate ComfyUI server from the one on ai-kvm2 (which
-    get_comfyui_client() targets). Local MiniMax-H3 generation is routed here
-    because the H3 models + workflow live on the Windows machine
-    (ComfyUI portable, reachable via COMFYUI_WINDOWS_HOST / COMFYUI_WINDOWS_PORT).
-
-    Returns None when the host/port haven't been configured, so any
-    dependent adapter/registration is skipped gracefully.
-    """
-    global _windows_comfyui_client
-    if _windows_comfyui_client is not None:
-        return _windows_comfyui_client
-
-    host = os.getenv("COMFYUI_WINDOWS_HOST", "").strip()
-    port = int(os.getenv("COMFYUI_WINDOWS_PORT", "8188") or "8188")
-    if not host:
-        logger.info(
-            "⬛ COMFYUI_WINDOWS_HOST not set — Windows ComfyUI client unavailable"
-        )
-        return None
-
-    _windows_comfyui_client = ComfyUIClient(host=host, port=port)
-    logger.info(f"🪟 Windows ComfyUI client ready: {host}:{port}")
-    return _windows_comfyui_client
-
-
 # ── Generic per-backend ComfyUI clients ─────────────────────────────
 # The Compute Backend Inventory (generation/compute_backends.py) drives which
 # server an adapter targets. get_comfyui_client_for_backend() returns a
 # (cached) ComfyUIClient for any configured 'comfyui' backend so adding a new
-# server is purely a config change.
+# server is purely a config change (Admin panel → compute_backends.json, or the
+# COMPUTE_NODE_* env fallback) — there is no longer a bespoke per-server client
+# factory.
 _backend_clients: dict = {}
 
 

--- a/src/backend/generation/adapters/local/minimax_h3_i2v.py
+++ b/src/backend/generation/adapters/local/minimax_h3_i2v.py
@@ -1,11 +1,12 @@
 """
-MiniMax-H3 Local I2V adapter — image-to-video (+audio) via the user's Windows PC ComfyUI.
+MiniMax-H3 Local I2V adapter — image-to-video (+audio) via a remote ComfyUI node.
 
-Runs the MiniMax-H3 FL2VA workflow on the Windows PC's ComfyUI server
-(get_windows_comfyui_client()), separate from the default ai-kvm2 ComfyUI.
-The input image is anchored as the first keyframe. Because it targets a
-different server, this adapter uploads the input image itself
-(handles_own_image_upload=True) and the router skips its default pre-upload.
+Runs the MiniMax-H3 FL2VA workflow on the enabled 'comfyui' compute backend
+that declares the minimax_h3 model family (e.g. a second server), separate from
+the default ai-kvm2 ComfyUI. The input image is anchored as the first keyframe.
+Because it targets a different server, this adapter uploads the input image
+itself (handles_own_image_upload=True) and the router skips its default
+pre-upload.
 """
 
 from __future__ import annotations

--- a/src/backend/generation/adapters/local/minimax_h3_t2v.py
+++ b/src/backend/generation/adapters/local/minimax_h3_t2v.py
@@ -1,12 +1,13 @@
 """
-MiniMax-H3 Local T2V adapter — text-to-video (+audio) via the user's Windows PC ComfyUI.
+MiniMax-H3 Local T2V adapter — text-to-video (+audio) via a remote ComfyUI node.
 
-Runs the MiniMax-H3 FL2VA workflow on the Windows PC's ComfyUI server
-(get_windows_comfyui_client()), which is a DIFFERENT server from the default
-ComfyUI on ai-kvm2 (get_comfyui_client()). It uses the int8_convrot model set
-that was downloaded onto that machine (see download_minimax_h3.* and
-README_MiniMax_H3_workflow.md). The model always generates a synchronized
-soundtrack — no separate audio prompt needed.
+Runs the MiniMax-H3 FL2VA workflow on the enabled 'comfyui' compute backend
+that declares the minimax_h3 model family (e.g. a second server), which is a
+DIFFERENT server from the default ComfyUI on ai-kvm2. The client is injected
+via ``comfyui_client_fn`` (resolved from the compute backend inventory). It
+uses the int8_convrot model set that was downloaded onto that machine (see
+download_minimax_h3.* and README_MiniMax_H3_workflow.md). The model always
+generates a synchronized soundtrack — no separate audio prompt needed.
 """
 
 from __future__ import annotations

--- a/src/backend/generation/compute_backends.json.example
+++ b/src/backend/generation/compute_backends.json.example
@@ -17,7 +17,7 @@
       "base_url": "http://windows-pc.test.invalid:8188",
       "enabled": false,
       "model_families": ["minimax_h3"],
-      "notes": "User's Windows PC (ComfyUI portable) running local MiniMax-H3. Set the real host via COMFYUI_WINDOWS_HOST in .env or the Admin panel (never commit it)."
+      "notes": "User's Windows PC (ComfyUI portable) running local MiniMax-H3. Set the real host here via the Admin panel, or via COMPUTE_NODE_2_HOST in .env for the fresh-install fallback (never commit it)."
     },
     {
       "id": "runpod-cloud",

--- a/src/backend/generation/compute_backends.py
+++ b/src/backend/generation/compute_backends.py
@@ -4,8 +4,7 @@ Compute Backend Inventory — configurable sources of compute for OELALA generat
 Every generation runs on a *compute backend*. A backend is one of:
 
 - ``comfyui`` — any ComfyUI server (headless or desktop) reachable over HTTP by
-  ``base_url``. Both the ai-kvm2 default (``localhost:8188``) and the user's
-  Windows-PC (configured via ``COMFYUI_WINDOWS_HOST``) are ComfyUI backends.
+  ``base_url`` (e.g. the ai-kvm2 default ``localhost:8188``).
 - ``runpod`` — a serverless RunPod container, i.e. an ephemeral ComfyUI server
   submitted to via the RunPod client (submit_to_runpod_fn). RunPod is "just a
   container with a temporary ComfyUI server"; endpoint IDs stay in ``.env``.
@@ -15,10 +14,12 @@ registry + router use this inventory to pick an enabled backend per request, so
 adding a new ComfyUI server becomes a configuration change (Admin UI + JSON)
 instead of a code change.
 
-Configuration lives in ``compute_backends.json`` (same directory) and is editable
-through the Admin panel → "Compute" API. If the file is missing/unreadable the
-module falls back to a built-in default equal to the three known backends
-(ai-kvm2, Windows-PC, RunPod), so generation never breaks.
+Configuration lives in ``compute_backends.json`` (same directory, gitignored;
+see ``compute_backends.json.example``) and is editable through the Admin panel →
+"Compute" API — that is the source of truth. If the file is missing/unreadable
+the module falls back to a built-in default: the ``COMPUTE_NODE_*`` env schema
+when present (fresh-install fallback; see ``_nodes_from_env``), otherwise the two
+known backends (ai-kvm2 local, RunPod), so generation never breaks.
 """
 
 from __future__ import annotations
@@ -37,6 +38,16 @@ logger = logging.getLogger(__name__)
 # upscale, lipsync, faceswap, caption, voice-clone, mmaudio) — they run on the
 # default local ComfyUI.
 UTILITY_FAMILY = "utility"
+
+# Maps the generic COMPUTE_NODE_n_TYPE value to a backend type. Node types are
+# intentionally a small extensible enum: 'comfy' (any hosted/desktop ComfyUI
+# server) and 'runpod' (serverless container) today; a future node kind only
+# extends this map without touching any other code.
+_NODE_TYPE_MAP = {
+    "comfy": "comfyui",
+    "comfyui": "comfyui",  # accepted alias; canonical spelling is "comfy"
+    "runpod": "runpod",
+}
 
 
 class ComputeBackend(BaseModel):
@@ -98,13 +109,17 @@ _loaded = False
 
 
 def _default_backends() -> List[ComputeBackend]:
-    """Built-in fallback inventory (ai-kvm2, Windows-PC, RunPod).
+    """Built-in fallback inventory (missing/unreadable compute_backends.json).
 
-    The Windows-PC address comes solely from env config — it is never
-    hardcoded here. When ``COMFYUI_WINDOWS_HOST`` is unset the backend is
-    omitted entirely rather than created with an invalid empty base_url.
+    When ``COMPUTE_NODE_*`` env vars are present they fully define the fallback
+    inventory, so a fresh install can be bootstrapped per operator (see
+    ``_nodes_from_env``). Without them, falls back to the two known backends
+    (ai-kvm2 local, RunPod) so generation still works out of the box.
     """
-    backends = [
+    env_nodes = _nodes_from_env()
+    if env_nodes:
+        return env_nodes
+    return [
         ComputeBackend(
             id="ai-kvm2-comfyui",
             name="ai-kvm2 ComfyUI (local)",
@@ -128,20 +143,75 @@ def _default_backends() -> List[ComputeBackend]:
             ],
         ),
     ]
-    windows_host = os.getenv("COMFYUI_WINDOWS_HOST", "").strip()
-    if windows_host:
-        windows_port = os.getenv("COMFYUI_WINDOWS_PORT", "8188").strip() or "8188"
-        backends.insert(
-            1,
-            ComputeBackend(
-                id="windows-pc-comfyui",
-                name="Windows-PC ComfyUI",
-                type="comfyui",
-                base_url=f"http://{windows_host}:{windows_port}",
-                enabled=True,
-                model_families=["minimax_h3"],
-            ),
-        )
+
+
+def _nodes_from_env() -> List[ComputeBackend]:
+    """Parse the ``COMPUTE_NODE_*`` env schema into backends.
+
+    Each ``COMPUTE_NODE_{n}_*`` group declares one compute node:
+
+    - ``COMPUTE_NODE_{n}_TYPE`` — node type, mapped via ``_NODE_TYPE_MAP``
+      (canonical values ``comfy`` and ``runpod``; ``comfyui`` accepted as an
+      alias). Unknown types are skipped with a warning.
+    - ``COMPUTE_NODE_{n}_HOST`` (+ optional ``..._PORT``, default 8188) — the
+      address for a ``comfy`` node; ignored for ``runpod``. A missing host on a
+      ``comfy`` node skips it.
+    - ``COMPUTE_NODE_{n}_NAME`` — optional display name (defaults to the id).
+    - ``COMPUTE_NODE_{n}_MODEL_FAMILIES`` — comma-separated model families.
+
+    Node numbers are scanned from 1 upward and the scan stops at the first gap,
+    so the env groups must be contiguous (``COMPUTE_NODE_1..N``). Each node gets
+    the deterministic id ``node-{n}``. Any addresses come only from env config —
+    they are never hardcoded here.
+    """
+    backends: List[ComputeBackend] = []
+    idx = 1
+    while True:
+        prefix = f"COMPUTE_NODE_{idx}"
+        node_type = (os.getenv(f"{prefix}_TYPE", "") or "").strip().lower()
+        if not node_type:
+            # First gap ends the scan; the groups must be contiguous.
+            break
+        backend_type = _NODE_TYPE_MAP.get(node_type)
+        if backend_type is None:
+            logger.warning(
+                f"⚠️ Skipping {prefix}: unknown node type '{node_type}' "
+                "(supported: comfy, runpod)"
+            )
+            idx += 1
+            continue
+        node_id = f"node-{idx}"
+        name = (os.getenv(f"{prefix}_NAME", "") or "").strip() or node_id
+        families = [
+            fam.strip()
+            for fam in (os.getenv(f"{prefix}_MODEL_FAMILIES", "") or "").split(",")
+            if fam.strip()
+        ]
+        base_url = ""
+        if backend_type == "comfyui":
+            host = (os.getenv(f"{prefix}_HOST", "") or "").strip()
+            if not host:
+                logger.warning(
+                    f"⚠️ Skipping {prefix}: comfy node requires {prefix}_HOST"
+                )
+                idx += 1
+                continue
+            port = (os.getenv(f"{prefix}_PORT", "") or "").strip() or "8188"
+            base_url = f"http://{host}:{port}"
+        try:
+            backends.append(
+                ComputeBackend(
+                    id=node_id,
+                    name=name,
+                    type=backend_type,
+                    base_url=base_url,
+                    enabled=True,
+                    model_families=families,
+                )
+            )
+        except Exception as exc:
+            logger.warning(f"⚠️ Skipping {prefix}: invalid compute node ({exc})")
+        idx += 1
     return backends
 
 

--- a/src/backend/generation/factory.py
+++ b/src/backend/generation/factory.py
@@ -152,10 +152,10 @@ def create_registry(
 
         _register(Wan22LocalT2VQ6Adapter, comfyui_client_fn=wan22_client_fn)
 
-        # ── Local MiniMax-H3 (Windows PC ComfyUI) ──────────────
+        # ── Local MiniMax-H3 (remote ComfyUI node) ──────────────
         # Resolved through the Compute Backend Inventory instead of a hardcoded
         # client: any enabled 'comfyui' backend that runs minimax_h3 will be
-        # used (currently the Windows-PC server).
+        # used (could be a second server like a Windows PC).
         from .adapters.local.minimax_h3_t2v import MiniMaxH3LocalT2VAdapter
         from .adapters.local.minimax_h3_i2v import MiniMaxH3LocalI2VAdapter
 
@@ -171,7 +171,7 @@ def create_registry(
             _register(MiniMaxH3LocalI2VAdapter, comfyui_client_fn=h3_client_fn)
         else:
             logger.info(
-                "🪟 No enabled ComfyUI backend for minimax_h3 — skipping local MiniMax-H3 adapters"
+                "⚙️ No enabled ComfyUI backend for minimax_h3 — skipping local MiniMax-H3 adapters"
             )
 
         # ── Utility adapters ───────────────────────────────────

--- a/tests/test_compute_backends.py
+++ b/tests/test_compute_backends.py
@@ -1,8 +1,9 @@
 """
-Tests for the Compute Backend Inventory (modular compute sources).
+Tests for the Compute Backend Inventory (modular compute sources / node types).
 
-Covers: config loading, fallback defaults, backend lookup, model-family
-resolution (local-first), client-fn generation, and save/load round-trip.
+Covers: config loading, fallback defaults (incl. the COMPUTE_NODE_* env schema),
+backend lookup, model-family resolution (local-first), client-fn generation, and
+save/load round-trip.
 """
 
 import os
@@ -18,15 +19,36 @@ from generation import compute_backends as cb
 
 CLEAN_CONFIG = {
     "backends": [
-        {"id": "ai-kvm2-comfyui", "name": "ai-kvm2 ComfyUI (local)", "type": "comfyui",
-         "base_url": "http://localhost:8188", "enabled": True,
-         "model_families": ["wan2.2", "sdxl", "flux", "flux2", "krea2", "utility"]},
-        {"id": "windows-pc-comfyui", "name": "Windows-PC ComfyUI", "type": "comfyui",
-         "base_url": "http://windows-pc.test.invalid:8188", "enabled": True,
-         "model_families": ["minimax_h3"]},
-        {"id": "runpod-cloud", "name": "RunPod serverless cloud", "type": "runpod",
-         "base_url": "", "enabled": True,
-         "model_families": ["wan2.2", "ltx", "minimax_h3", "qwen_image_edit", "i2i_edit_model"]},
+        {
+            "id": "ai-kvm2-comfyui",
+            "name": "ai-kvm2 ComfyUI (local)",
+            "type": "comfyui",
+            "base_url": "http://localhost:8188",
+            "enabled": True,
+            "model_families": ["wan2.2", "sdxl", "flux", "flux2", "krea2", "utility"],
+        },
+        {
+            "id": "windows-pc-comfyui",
+            "name": "Windows-PC ComfyUI",
+            "type": "comfyui",
+            "base_url": "http://windows-pc.test.invalid:8188",
+            "enabled": True,
+            "model_families": ["minimax_h3"],
+        },
+        {
+            "id": "runpod-cloud",
+            "name": "RunPod serverless cloud",
+            "type": "runpod",
+            "base_url": "",
+            "enabled": True,
+            "model_families": [
+                "wan2.2",
+                "ltx",
+                "minimax_h3",
+                "qwen_image_edit",
+                "i2i_edit_model",
+            ],
+        },
     ]
 }
 
@@ -48,6 +70,34 @@ def reset_cache(tmp_path, monkeypatch):
     cb._backends = []
 
 
+def _clear_env_nodes(monkeypatch):
+    """Clear every COMPUTE_NODE_* / legacy COMFYUI_WINDOWS_* var so tests are
+    deterministic regardless of the developer's shell environment."""
+    for name in list(os.environ):
+        if name.startswith("COMPUTE_NODE_") or name.startswith("COMFYUI_WINDOWS_"):
+            monkeypatch.delenv(name, raising=False)
+
+
+def _set_env_nodes(monkeypatch, nodes):
+    """Set COMPUTE_NODE_* env groups for a test.
+
+    ``nodes``: dict of node index -> dict of suffix -> value, e.g. {1: {"type":
+    "comfy", "host": "localhost", "families": "sdxl"}}.
+    """
+    _clear_env_nodes(monkeypatch)
+    for idx, fields in nodes.items():
+        prefix = f"COMPUTE_NODE_{idx}"
+        monkeypatch.setenv(f"{prefix}_TYPE", fields["type"])
+        if "host" in fields:
+            monkeypatch.setenv(f"{prefix}_HOST", fields["host"])
+        if "port" in fields:
+            monkeypatch.setenv(f"{prefix}_PORT", fields["port"])
+        if "name" in fields:
+            monkeypatch.setenv(f"{prefix}_NAME", fields["name"])
+        if "families" in fields:
+            monkeypatch.setenv(f"{prefix}_MODEL_FAMILIES", fields["families"])
+
+
 def test_loads_inventory_from_json():
     backends = cb.load_backends(force=True)
     ids = [b.id for b in backends]
@@ -58,17 +108,125 @@ def test_loads_inventory_from_json():
 
 def test_default_fallback_when_json_missing(monkeypatch):
     from pathlib import Path
-    # Force the missing-file branch and clear the env so the fallback inventory
-    # is fully deterministic (Windows-PC backend is only added when
-    # COMFYUI_WINDOWS_HOST is set).
+
+    # Force the missing-file branch and clear all env node vars so the fallback
+    # is fully deterministic (COMPUTE_NODE_* builds the fallback when present;
+    # otherwise the two hardcoded backends ai-kvm2 + runpod).
     monkeypatch.setattr(cb, "_json_path", Path("/nonexistent/path/backends.json"))
-    monkeypatch.delenv("COMFYUI_WINDOWS_HOST", raising=False)
+    _clear_env_nodes(monkeypatch)
     cb._loaded = False
     backends = cb.load_backends(force=True)
     ids = [b.id for b in backends]
     assert "ai-kvm2-comfyui" in ids
     assert "runpod-cloud" in ids
     assert "windows-pc-comfyui" not in ids
+
+
+def test_env_fallback_builds_nodes(monkeypatch):
+    _set_env_nodes(
+        monkeypatch,
+        {
+            1: {
+                "type": "comfy",
+                "host": "localhost",
+                "port": "8188",
+                "name": "ai-kvm2",
+                "families": "wan2.2,sdxl,flux,flux2,krea2,utility",
+            },
+            2: {
+                "type": "comfy",
+                "host": "node2.test.invalid",
+                "name": "Second server",
+                "families": "minimax_h3",
+            },
+            3: {"type": "runpod", "name": "RunPod", "families": "ltx,minimax_h3"},
+        },
+    )
+    from pathlib import Path
+
+    monkeypatch.setattr(cb, "_json_path", Path("/nonexistent/env-fallback.json"))
+    cb._loaded = False
+    backends = cb.load_backends(force=True)
+
+    assert [b.id for b in backends] == ["node-1", "node-2", "node-3"]
+    b1, b2, b3 = backends
+    assert (b1.id, b1.type, b1.base_url) == (
+        "node-1",
+        "comfyui",
+        "http://localhost:8188",
+    )
+    assert b1.model_families == ["wan2.2", "sdxl", "flux", "flux2", "krea2", "utility"]
+    # Port defaults to 8188 when omitted.
+    assert b2.base_url == "http://node2.test.invalid:8188"
+    assert b2.model_families == ["minimax_h3"]
+    # A runpod node carries no base_url.
+    assert b3.type == "runpod" and b3.base_url == ""
+
+
+def test_env_fallback_accepts_comfyui_alias(monkeypatch):
+    _set_env_nodes(
+        monkeypatch,
+        {1: {"type": "comfyui", "host": "localhost", "families": "sdxl"}},
+    )
+    from pathlib import Path
+
+    monkeypatch.setattr(cb, "_json_path", Path("/nonexistent/env-fallback.json"))
+    cb._loaded = False
+    backends = cb.load_backends(force=True)
+    assert len(backends) == 1
+    assert backends[0].type == "comfyui"
+    assert backends[0].base_url == "http://localhost:8188"
+
+
+def test_env_fallback_skips_unknown_type(monkeypatch):
+    _set_env_nodes(
+        monkeypatch,
+        {
+            1: {"type": "bogus", "host": "localhost", "families": "sdxl"},
+            2: {"type": "comfy", "host": "localhost", "families": "sdxl"},
+            3: {"type": "runpod", "families": "ltx"},
+        },
+    )
+    from pathlib import Path
+
+    monkeypatch.setattr(cb, "_json_path", Path("/nonexistent/env-fallback.json"))
+    cb._loaded = False
+    backends = cb.load_backends(force=True)
+    # bogus is skipped; the scan continues onto the valid nodes.
+    assert [b.id for b in backends] == ["node-2", "node-3"]
+
+
+def test_env_fallback_skips_comfy_without_host(monkeypatch):
+    _set_env_nodes(
+        monkeypatch,
+        {
+            1: {"type": "comfy", "families": "sdxl"},  # no HOST -> skipped
+            2: {"type": "runpod", "families": "ltx"},
+        },
+    )
+    from pathlib import Path
+
+    monkeypatch.setattr(cb, "_json_path", Path("/nonexistent/env-fallback.json"))
+    cb._loaded = False
+    backends = cb.load_backends(force=True)
+    assert [b.id for b in backends] == ["node-2"]
+
+
+def test_env_fallback_stops_at_first_gap(monkeypatch):
+    # Node 2 absent -> only node-1 is read (groups must be contiguous).
+    _set_env_nodes(
+        monkeypatch,
+        {
+            1: {"type": "comfy", "host": "localhost", "families": "sdxl"},
+            3: {"type": "runpod", "families": "ltx"},
+        },
+    )
+    from pathlib import Path
+
+    monkeypatch.setattr(cb, "_json_path", Path("/nonexistent/env-fallback.json"))
+    cb._loaded = False
+    backends = cb.load_backends(force=True)
+    assert [b.id for b in backends] == ["node-1"]
 
 
 def test_get_backend():
@@ -111,15 +269,28 @@ def test_enabled_filter_excludes_disabled(tmp_path, monkeypatch):
     # Point the module at a throwaway file so we don't touch the real config.
     fp = tmp_path / "backends.json"
     fp.write_text(
-        json.dumps({
-            "backends": [
-                {"id": "windows-pc-comfyui", "name": "Windows", "type": "comfyui",
-                 "base_url": "http://windows-pc.test.invalid:8188", "enabled": True,
-                 "model_families": ["minimax_h3"]},
-                {"id": "runpod-cloud", "name": "RunPod", "type": "runpod",
-                 "base_url": "", "enabled": True, "model_families": ["minimax_h3"]},
-            ]
-        })
+        json.dumps(
+            {
+                "backends": [
+                    {
+                        "id": "windows-pc-comfyui",
+                        "name": "Windows",
+                        "type": "comfyui",
+                        "base_url": "http://windows-pc.test.invalid:8188",
+                        "enabled": True,
+                        "model_families": ["minimax_h3"],
+                    },
+                    {
+                        "id": "runpod-cloud",
+                        "name": "RunPod",
+                        "type": "runpod",
+                        "base_url": "",
+                        "enabled": True,
+                        "model_families": ["minimax_h3"],
+                    },
+                ]
+            }
+        )
     )
     monkeypatch.setattr(cb, "_json_path", fp)
     cb._loaded = False
@@ -187,16 +358,28 @@ def test_skips_invalid_backend_type_keeps_others(tmp_path, monkeypatch):
     # instead of resetting the whole inventory to built-in defaults.
     fp = tmp_path / "backends.json"
     fp.write_text(
-        json.dumps({
-            "backends": [
-                {"id": "good", "name": "Good", "type": "comfyui",
-                 "base_url": "http://localhost:8188", "enabled": True,
-                 "model_families": ["sdxl"]},
-                {"id": "bad", "name": "Bad", "type": "bogus",
-                 "base_url": "http://localhost:9999", "enabled": True,
-                 "model_families": ["sdxl"]},
-            ]
-        })
+        json.dumps(
+            {
+                "backends": [
+                    {
+                        "id": "good",
+                        "name": "Good",
+                        "type": "comfyui",
+                        "base_url": "http://localhost:8188",
+                        "enabled": True,
+                        "model_families": ["sdxl"],
+                    },
+                    {
+                        "id": "bad",
+                        "name": "Bad",
+                        "type": "bogus",
+                        "base_url": "http://localhost:9999",
+                        "enabled": True,
+                        "model_families": ["sdxl"],
+                    },
+                ]
+            }
+        )
     )
     monkeypatch.setattr(cb, "_json_path", fp)
     cb._loaded = False
@@ -211,18 +394,30 @@ def test_rejects_non_http_scheme_for_comfyui_backend():
     # silently ignored, so the inventory model must reject it explicitly.
     with pytest.raises(Exception):
         cb.ComputeBackend(
-            id="https-bad", name="HTTPS", type="comfyui",
-            base_url="https://192.0.2.1:8188", enabled=True, model_families=[],
+            id="https-bad",
+            name="HTTPS",
+            type="comfyui",
+            base_url="https://192.0.2.1:8188",
+            enabled=True,
+            model_families=[],
         )
     with pytest.raises(Exception):
         cb.ComputeBackend(
-            id="ftp-bad", name="FTP", type="comfyui",
-            base_url="ftp://192.0.2.1:21", enabled=True, model_families=[],
+            id="ftp-bad",
+            name="FTP",
+            type="comfyui",
+            base_url="ftp://192.0.2.1:21",
+            enabled=True,
+            model_families=[],
         )
     # Plain http (and scheme-less host:port) remain valid.
     cb.ComputeBackend(
-        id="http-ok", name="HTTP", type="comfyui",
-        base_url="http://192.0.2.1:8188", enabled=True, model_families=[],
+        id="http-ok",
+        name="HTTP",
+        type="comfyui",
+        base_url="http://192.0.2.1:8188",
+        enabled=True,
+        model_families=[],
     )
 
 
@@ -233,17 +428,29 @@ def test_rejects_invalid_port_for_comfyui_backend():
     for bad in ("http://192.0.2.1:abc", "http://192.0.2.1:0", "http://192.0.2.1:65536"):
         with pytest.raises(Exception):
             cb.ComputeBackend(
-                id="port-bad", name="Bad port", type="comfyui",
-                base_url=bad, enabled=True, model_families=[],
+                id="port-bad",
+                name="Bad port",
+                type="comfyui",
+                base_url=bad,
+                enabled=True,
+                model_families=[],
             )
     # A valid port and a portless host both still load.
     cb.ComputeBackend(
-        id="port-ok", name="OK port", type="comfyui",
-        base_url="http://192.0.2.1:8188", enabled=True, model_families=[],
+        id="port-ok",
+        name="OK port",
+        type="comfyui",
+        base_url="http://192.0.2.1:8188",
+        enabled=True,
+        model_families=[],
     )
     cb.ComputeBackend(
-        id="portless-ok", name="No port", type="comfyui",
-        base_url="http://192.0.2.1", enabled=True, model_families=[],
+        id="portless-ok",
+        name="No port",
+        type="comfyui",
+        base_url="http://192.0.2.1",
+        enabled=True,
+        model_families=[],
     )
 
 
@@ -254,8 +461,12 @@ def test_get_comfyui_client_for_backend_refreshes_on_base_url_change(monkeypatch
     from comfyui_client import get_comfyui_client_for_backend
 
     b = cb.ComputeBackend(
-        id="test-backend", name="Test", type="comfyui",
-        base_url="http://192.0.2.1:8188", enabled=True, model_families=[],
+        id="test-backend",
+        name="Test",
+        type="comfyui",
+        base_url="http://192.0.2.1:8188",
+        enabled=True,
+        model_families=[],
     )
     c1 = get_comfyui_client_for_backend(b)
     b.base_url = "http://192.0.2.2:8188"

--- a/tests/test_local_minimax_h3.py
+++ b/tests/test_local_minimax_h3.py
@@ -1,8 +1,9 @@
 """
-Tests for local MiniMax-H3 adapters (Windows PC ComfyUI).
+Tests for local MiniMax-H3 adapters (remote ComfyUI node).
 
-These adapters route MiniMax-H3 generation to the user's Windows PC ComfyUI
-server (get_windows_comfyui_client) instead of the default ai-kvm2 ComfyUI.
+These adapters route MiniMax-H3 generation to the 'comfyui' compute backend
+that declares the minimax_h3 family (e.g. a second server), resolved via the
+compute backend inventory instead of the default ai-kvm2 ComfyUI.
 
 Covers: metadata, constraints, cost, workflow delegation, execute (t2v + i2v,
 including the adapter-level image upload for i2v).
@@ -40,7 +41,11 @@ def _png_b64() -> str:
 
 
 def _req(**kw):
-    base = {"operation": Operation.GENERATE, "target_type": MediaType.VIDEO, "prompt": "test"}
+    base = {
+        "operation": Operation.GENERATE,
+        "target_type": MediaType.VIDEO,
+        "prompt": "test",
+    }
     base.update(kw)
     return GenerationRequest(**base)
 
@@ -65,9 +70,14 @@ class TestMiniMaxH3LocalT2V:
         assert c.supports_negative_prompt is False
         assert "16:9" in c.aspect_ratios
 
-    @pytest.mark.parametrize("frames,expected", [
-        (124, 8), (210, 12), (362, 15),
-    ])
+    @pytest.mark.parametrize(
+        "frames,expected",
+        [
+            (124, 8),
+            (210, 12),
+            (362, 15),
+        ],
+    )
     def test_cost(self, frames, expected):
         assert MiniMaxH3LocalT2VAdapter().cost(_req(frames=frames)) == expected
 
@@ -75,7 +85,9 @@ class TestMiniMaxH3LocalT2V:
         mock = MagicMock()
         mock.build_local_minimax_h3_t2v_workflow.return_value = {"h3": "wf"}
         a = MiniMaxH3LocalT2VAdapter(comfyui_client_fn=lambda: mock)
-        req = _req(frames=124, fps=24, seed=5, steps=20, aspect_ratio="16:9", megapixels=0.98)
+        req = _req(
+            frames=124, fps=24, seed=5, steps=20, aspect_ratio="16:9", megapixels=0.98
+        )
         wf = a.build_workflow(req)
         assert wf == {"h3": "wf"}
         mock.build_local_minimax_h3_t2v_workflow.assert_called_once()
@@ -130,9 +142,14 @@ class TestMiniMaxH3LocalI2V:
         assert c.allowed_fps == [24]
         assert c.supports_negative_prompt is False
 
-    @pytest.mark.parametrize("frames,expected", [
-        (124, 5), (210, 8), (362, 15),
-    ])
+    @pytest.mark.parametrize(
+        "frames,expected",
+        [
+            (124, 5),
+            (210, 8),
+            (362, 15),
+        ],
+    )
     def test_cost(self, frames, expected):
         assert MiniMaxH3LocalI2VAdapter().cost(_req(frames=frames)) == expected
 
@@ -153,7 +170,10 @@ class TestMiniMaxH3LocalI2V:
         mock.upload_image_from_bytes.assert_called_once()
         # and the workflow built with the returned filename
         mock.build_local_minimax_h3_i2v_workflow.assert_called_once()
-        assert mock.build_local_minimax_h3_i2v_workflow.call_args[1]["image_name"] == "v2_minimax_i2v_input.png"
+        assert (
+            mock.build_local_minimax_h3_i2v_workflow.call_args[1]["image_name"]
+            == "v2_minimax_i2v_input.png"
+        )
 
     @pytest.mark.asyncio
     async def test_execute_requires_image(self):


### PR DESCRIPTION
## Summary

Generalizes the compute backend configuration away from the bespoke Windows-PC path into **named, typed compute nodes**. The compute backend inventory (`Admin panel → Compute` / `compute_backends.json`) is the single source of truth; env config is only the fresh-install fallback.

## What changed

- **New `COMPUTE_NODE_{n}_*` env schema** (fallback only), one group per node:
  - `TYPE` — `comfy` | `runpod` (extensible enum; `comfyui` accepted as alias)
  - `HOST` (+ optional `PORT`, default 8188) for `comfy` nodes; ignored for `runpod`
  - `NAME` — display label; `MODEL_FAMILIES` — comma list
  - deterministic ids `node-{n}`; contiguous numbering (scan stops at first gap); invalid groups skipped with a warning
- **Removed the legacy Windows path**: `get_windows_comfyui_client()` and `COMFYUI_WINDOWS_HOST` / `COMFYUI_WINDOWS_PORT`. A second server (e.g. Windows-PC running local MiniMax-H3) is now just another `comfyui` backend resolved through the inventory (`get_comfyui_client_for_backend`).
- **Queue indicator / job-result resolution** now poll the actual backend each local job is tagged with (by `backend_id`) instead of a hardcoded windows branch; the `server` label shows the backend name.
- Docs / AGENTS (synced copies) / `.env.example` / `compute_backends.json.example` / adapter docstrings reworded to generic compute-node language — **no hardcoded addresses anywhere** (placeholders `windows-pc.test.invalid`, tests use dummy hosts + TEST-NET IPs).

## Merge order

This PR targets `chore/remove-hardcoded-ips` (#188) so its diff stays clean and doesn't duplicate the IP-removal work. Merge #188 first, then this one; after #188 merges into `main` the base here can be retargeted to `main` with no change in content.

## Tests

- `tests/test_compute_backends.py` extended with `COMPUTE_NODE_*` schema tests (build, alias, unknown-type skip, missing-host skip, gap stop)
- `ruff check` + `ruff format` clean on touched files
- `pytest tests/test_compute_backends.py tests/test_local_minimax_h3.py tests/test_generation_core.py` → 39 + 119 passed